### PR TITLE
Use Foundry Stable Release

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,4 +7,4 @@ runs:
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: nightly
+        version: stable


### PR DESCRIPTION
Since v1.0, it is recommended to use stable releases, as nightly releases will often have breaking changes.