### PR TITLE
use `uint48` instead of `uint32` for block numbers

### DIFF
--- a/src/general/AntiSandwichHook.sol
+++ b/src/general/AntiSandwichHook.sol
@@ -51,7 +51,7 @@ contract AntiSandwichHook is BaseDynamicAfterFee {
 
     /// @dev Represents a checkpoint of the pool state at the beginning of a block.
     struct Checkpoint {
-        uint32 blockNumber;
+        uint48 blockNumber;
         Slot0 slot0;
         Pool.State state;
     }
@@ -84,7 +84,7 @@ contract AntiSandwichHook is BaseDynamicAfterFee {
         Checkpoint storage _lastCheckpoint = _lastCheckpoints[poolId];
 
         // update the top-of-block `slot0` if new block
-        if (_lastCheckpoint.blockNumber != uint32(block.number)) {
+        if (_lastCheckpoint.blockNumber != uint48(block.number)) {
             _lastCheckpoint.slot0 = Slot0.wrap(poolManager.extsload(StateLibrary._getPoolStateSlot(poolId)));
             return (this.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
         }
@@ -110,7 +110,7 @@ contract AntiSandwichHook is BaseDynamicAfterFee {
         BalanceDelta delta,
         bytes calldata hookData
     ) internal override returns (bytes4, int128) {
-        uint32 blockNumber = uint32(block.number);
+        uint48 blockNumber = uint48(block.number);
         PoolId poolId = key.toId();
         Checkpoint storage _lastCheckpoint = _lastCheckpoints[poolId];
 


### PR DESCRIPTION
Using `uint48` for handling block numbers instead of `uint32` due to the possibility of having the Uniswap protocol deployed on chains with sub 1 second blocks, which would be limited in the long term with `uint32`.