### PR TITLE
Solve https://github.com/OpenZeppelin/uniswap-hooks/issues/73

### DIFF
--- a/src/general/LiquidityPenaltyHook.sol
+++ b/src/general/LiquidityPenaltyHook.sol
@@ -55,7 +55,7 @@ contract LiquidityPenaltyHook is BaseHook {
     error BlockNumberOffsetTooLow();
 
     /**
-     * @dev A penalty was attempted to be applied donated to LP's in range, but there aren't any.
+     * @dev A penalty was attempted to be applied and donated to LP's in range, but there aren't any.
      */
     error NoLiquidityToReceiveDonation();
 

--- a/src/general/LiquidityPenaltyHook.sol
+++ b/src/general/LiquidityPenaltyHook.sol
@@ -19,7 +19,6 @@ import {PoolId} from "v4-core/src/types/PoolId.sol";
 import {Currency} from "v4-core/src/types/Currency.sol";
 import {ModifyLiquidityParams} from "v4-core/src/types/PoolOperation.sol";
 import {BalanceDelta, BalanceDeltaLibrary, toBalanceDelta} from "v4-core/src/types/BalanceDelta.sol";
-import {Pool} from "v4-core/src/libraries/Pool.sol";
 
 /**
  * @dev Just-in-Time (JIT) liquidity provisioning resistant hook.

--- a/src/general/LiquidityPenaltyHook.sol
+++ b/src/general/LiquidityPenaltyHook.sol
@@ -170,7 +170,7 @@ contract LiquidityPenaltyHook is BaseHook {
     /**
      * @dev Takes `feeDelta` from a liquidity position as `withheldFees` into this hook.
      */
-    function _takeFeesToHook(PoolKey calldata key, bytes32 positionKey, BalanceDelta feeDelta) internal {
+    function _takeFeesToHook(PoolKey calldata key, bytes32 positionKey, BalanceDelta feeDelta) internal virtual {
         PoolId poolId = key.toId();
 
         _withheldFees[poolId][positionKey] = _withheldFees[poolId][positionKey] + feeDelta;
@@ -184,6 +184,7 @@ contract LiquidityPenaltyHook is BaseHook {
      */
     function _settleFeesFromHook(PoolKey calldata key, bytes32 positionKey)
         internal
+        virtual
         returns (BalanceDelta withheldFees)
     {
         PoolId poolId = key.toId();
@@ -249,7 +250,7 @@ contract LiquidityPenaltyHook is BaseHook {
      * removed without penalty. During this period, JIT attacks are deterred through fee withholding
      * and penalties. Higher values provide stronger JIT protection but may discourage legitimate LPs.
      */
-    function getBlockNumberOffset() public view returns (uint48) {
+    function getBlockNumberOffset() public view virtual returns (uint48) {
         return _blockNumberOffset;
     }
 
@@ -267,7 +268,7 @@ contract LiquidityPenaltyHook is BaseHook {
     /**
      * @dev Returns the `withheldFees` for a liquidity position.
      */
-    function getWithheldFees(PoolId poolId, bytes32 positionKey) public view returns (BalanceDelta) {
+    function getWithheldFees(PoolId poolId, bytes32 positionKey) public view virtual returns (BalanceDelta) {
         return _withheldFees[poolId][positionKey];
     }
 

--- a/test/general/LiquidityPenaltyHook.t.sol
+++ b/test/general/LiquidityPenaltyHook.t.sol
@@ -137,10 +137,10 @@ contract LiquidityPenaltyHookTest is HookTest {
         vm.expectRevert(
             abi.encodeWithSelector(
                 CustomRevert.WrappedError.selector,
-                address(hook),                                    // target address
-                IHooks.afterRemoveLiquidity.selector,            // function selector
+                address(hook), // target address
+                IHooks.afterRemoveLiquidity.selector, // function selector
                 abi.encodeWithSelector(LiquidityPenaltyHook.NoLiquidityToReceiveDonation.selector), // reason
-                abi.encodeWithSelector(Hooks.HookCallFailed.selector)  // details
+                abi.encodeWithSelector(Hooks.HookCallFailed.selector) // details
             )
         );
         BalanceDelta hookDelta = modifyPoolLiquidity(key, -600, 600, -int128(liquidityHookKey), 0);

--- a/test/general/LiquidityPenaltyHook.t.sol
+++ b/test/general/LiquidityPenaltyHook.t.sol
@@ -18,6 +18,7 @@ import {PoolKey} from "v4-core/src/types/PoolKey.sol";
 import {PoolSwapTest} from "v4-core/src/test/PoolSwapTest.sol";
 import {HookTest} from "test/utils/HookTest.sol";
 import {toBalanceDelta} from "v4-core/src/types/BalanceDelta.sol";
+import {CustomRevert} from "v4-core/src/libraries/CustomRevert.sol";
 
 contract LiquidityPenaltyHookTest is HookTest {
     LiquidityPenaltyHook hook;
@@ -129,10 +130,28 @@ contract LiquidityPenaltyHookTest is HookTest {
         uint128 liquidityNoHookKey = StateLibrary.getLiquidity(manager, noHookKey.toId());
 
         // remove entire liquidity
-        BalanceDelta hookDelta = modifyPoolLiquidity(key, -600, 600, -int128(liquidityHookKey), 0);
         BalanceDelta noHookDelta = modifyPoolLiquidity(noHookKey, -600, 600, -int128(liquidityNoHookKey), 0);
 
-        assertEq(hookDelta, noHookDelta, "Hooked: penalty not applied when removing entire liquidity");
+        // Can't withdraw all liquidity in the hooked since the attacker is the sole lp in range, and there
+        // is no other active liquidity positions in range to receive the donation. Offset must be awaited.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CustomRevert.WrappedError.selector,
+                address(hook),                                    // target address
+                IHooks.afterRemoveLiquidity.selector,            // function selector
+                abi.encodeWithSelector(LiquidityPenaltyHook.NoLiquidityToReceiveDonation.selector), // reason
+                abi.encodeWithSelector(Hooks.HookCallFailed.selector)  // details
+            )
+        );
+        BalanceDelta hookDelta = modifyPoolLiquidity(key, -600, 600, -int128(liquidityHookKey), 0);
+
+        // advance block
+        vm.roll(block.number + 1);
+
+        // now the attacker can remove without penalty
+        BalanceDelta hookDeltaAfterOffset = modifyPoolLiquidity(key, -600, 600, -int128(liquidityHookKey), 0);
+
+        assertEq(hookDeltaAfterOffset, noHookDelta, "Hooked: penalty not applied after offset.");
     }
 
     function test_JIT_Swap() public {

--- a/test/utils/BalanceDeltaAssertions.sol
+++ b/test/utils/BalanceDeltaAssertions.sol
@@ -7,19 +7,19 @@ import {Test} from "forge-std/Test.sol";
 // @dev Custom foundry-like assertions for `BalanceDelta` from `v4-core`
 contract BalanceDeltaAssertions is Test {
     // @dev Asserts that `delta1` is equal to `delta2` for both amount0 and amount1
-    function assertEq(BalanceDelta delta1, BalanceDelta delta2) internal {
+    function assertEq(BalanceDelta delta1, BalanceDelta delta2) internal pure {
         assertEq(BalanceDeltaLibrary.amount1(delta1), BalanceDeltaLibrary.amount1(delta2));
         assertEq(BalanceDeltaLibrary.amount0(delta1), BalanceDeltaLibrary.amount0(delta2));
     }
 
     // @dev Asserts that `delta1` is equal to `delta2` for both amount0 and amount1 with a custom error message
-    function assertEq(BalanceDelta delta1, BalanceDelta delta2, string memory err) internal {
+    function assertEq(BalanceDelta delta1, BalanceDelta delta2, string memory err) internal pure {
         assertEq(BalanceDeltaLibrary.amount1(delta1), BalanceDeltaLibrary.amount1(delta2), err);
         assertEq(BalanceDeltaLibrary.amount0(delta1), BalanceDeltaLibrary.amount0(delta2), err);
     }
 
     // @dev Asserts that `delta1` is approximately equal to `delta2` for both amount0 and amount1
-    function assertAproxEqAbs(BalanceDelta delta1, BalanceDelta delta2, uint256 absTolerance) internal {
+    function assertAproxEqAbs(BalanceDelta delta1, BalanceDelta delta2, uint256 absTolerance) internal pure {
         assertApproxEqAbs(BalanceDeltaLibrary.amount1(delta1), BalanceDeltaLibrary.amount1(delta2), absTolerance);
         assertApproxEqAbs(BalanceDeltaLibrary.amount0(delta1), BalanceDeltaLibrary.amount0(delta2), absTolerance);
     }
@@ -27,46 +27,47 @@ contract BalanceDeltaAssertions is Test {
     // @dev Asserts that `delta1` is approximately equal to `delta2` for both amount0 and amount1 with a custom error message
     function assertAproxEqAbs(BalanceDelta delta1, BalanceDelta delta2, uint256 absTolerance, string memory err)
         internal
+        pure
     {
         assertApproxEqAbs(BalanceDeltaLibrary.amount1(delta1), BalanceDeltaLibrary.amount1(delta2), absTolerance, err);
         assertApproxEqAbs(BalanceDeltaLibrary.amount0(delta1), BalanceDeltaLibrary.amount0(delta2), absTolerance, err);
     }
 
     // @dev Asserts that `delta1` is not equal to `delta2` for both amount0 and amount1
-    function assertNotEq(BalanceDelta delta1, BalanceDelta delta2) internal {
+    function assertNotEq(BalanceDelta delta1, BalanceDelta delta2) internal pure {
         bool amount0Different = BalanceDeltaLibrary.amount0(delta1) != BalanceDeltaLibrary.amount0(delta2);
         bool amount1Different = BalanceDeltaLibrary.amount1(delta1) != BalanceDeltaLibrary.amount1(delta2);
         assertTrue(amount0Different || amount1Different);
     }
 
     // @dev Asserts that `delta1` is not equal to `delta2` for both amount0 and amount1 with a custom error message
-    function assertNotEq(BalanceDelta delta1, BalanceDelta delta2, string memory err) internal {
+    function assertNotEq(BalanceDelta delta1, BalanceDelta delta2, string memory err) internal pure {
         bool amount0Different = BalanceDeltaLibrary.amount0(delta1) != BalanceDeltaLibrary.amount0(delta2);
         bool amount1Different = BalanceDeltaLibrary.amount1(delta1) != BalanceDeltaLibrary.amount1(delta2);
         assertTrue(amount0Different || amount1Different, err);
     }
 
     // @dev Asserts that delta1 is greater than delta2 for both amount0 and amount1
-    function assertGt(BalanceDelta delta1, BalanceDelta delta2) internal {
+    function assertGt(BalanceDelta delta1, BalanceDelta delta2) internal pure {
         assertGt(BalanceDeltaLibrary.amount1(delta1), BalanceDeltaLibrary.amount1(delta2));
         assertGt(BalanceDeltaLibrary.amount0(delta1), BalanceDeltaLibrary.amount0(delta2));
     }
 
     // @dev Asserts that `delta1` is greater than `delta2` for both amount0 and amount1 with a custom error message
-    function assertGt(BalanceDelta delta1, BalanceDelta delta2, string memory err) internal {
+    function assertGt(BalanceDelta delta1, BalanceDelta delta2, string memory err) internal pure {
         assertGt(BalanceDeltaLibrary.amount1(delta1), BalanceDeltaLibrary.amount1(delta2), err);
         assertGt(BalanceDeltaLibrary.amount0(delta1), BalanceDeltaLibrary.amount0(delta2), err);
     }
 
     // @dev Asserts that delta1 is greater than delta2 for either amount0 or amount1
-    function assertEitherGt(BalanceDelta delta1, BalanceDelta delta2) internal {
+    function assertEitherGt(BalanceDelta delta1, BalanceDelta delta2) internal pure {
         bool amount1Gt = BalanceDeltaLibrary.amount1(delta1) > BalanceDeltaLibrary.amount1(delta2);
         bool amount0Gt = BalanceDeltaLibrary.amount0(delta1) > BalanceDeltaLibrary.amount0(delta2);
         assertTrue(amount1Gt || amount0Gt);
     }
 
     // @dev Asserts that delta1 is greater than delta2 for either amount0 or amount1 with a custom error message
-    function assertEitherGt(BalanceDelta delta1, BalanceDelta delta2, string memory err) internal {
+    function assertEitherGt(BalanceDelta delta1, BalanceDelta delta2, string memory err) internal pure {
         bool amount1Gt = BalanceDeltaLibrary.amount1(delta1) > BalanceDeltaLibrary.amount1(delta2);
         bool amount0Gt = BalanceDeltaLibrary.amount0(delta1) > BalanceDeltaLibrary.amount0(delta2);
         assertTrue(amount1Gt || amount0Gt, err);


### PR DESCRIPTION
- Solve https://github.com/OpenZeppelin/uniswap-hooks/issues/73, making the liquidity removal revert if there is a pending penalty and there is no liquidity in range.
- Added pure to all assertions in `BalanceDeltaAssertions.sol`
- Removed some SLOAD's and added early returns to save some gas during penalty calculation. 