### PR TITLE
Remove PoolManager from constructor params

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,5 +18,3 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
-      with:
-        version: nightly

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,7 +9,7 @@ optimizer_runs  = 200                                   # The number of optimize
 fs_permissions  = [{ access = "read", path = "./"}]     # Gives permission to read files for deployment keys.
 evm_version     = "cancun"                              # The EVM version to use
 ffi             = true                                  # Enable the foreign function interface (ffi) cheatcode.
-gas_limit = 100000000
+gas_limit = 200000000
 no_match_path   = "src/mocks/**/*.sol"                  # Exclude mocks from compilation and testing
 
 [fuzz]
@@ -36,3 +36,6 @@ runs           = 1024       # The number of times to run the fuzzing tests
 [profile.super_deep.invariant]
 runs           = 16         # The number of calls to make in the invariant tests
 depth          = 16         # The number of times to run the invariant tests
+
+[profile.oracle]
+gas_limit = 300000000       # Higher gas limit for oracle tests

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,6 @@
 [profile.default]
 src             = 'src'                                 # The source directory
+test            = 'test'                                # The test directory
 out             = 'out'                                 # The output directory
 libs            = ['lib']                               # A list of library directories
 solc            = "0.8.26"                              # The Solidity compiler version
@@ -9,6 +10,7 @@ fs_permissions  = [{ access = "read", path = "./"}]     # Gives permission to re
 evm_version     = "cancun"                              # The EVM version to use
 ffi             = true                                  # Enable the foreign function interface (ffi) cheatcode.
 gas_limit = 100000000
+no_match_path   = "src/mocks/**/*.sol"                  # Exclude mocks from compilation and testing
 
 [fuzz]
 runs           = 256        # The number of times to run the fuzzing tests

--- a/src/base/BaseAsyncSwap.sol
+++ b/src/base/BaseAsyncSwap.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.26;
 // External imports
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {
     BeforeSwapDelta, BeforeSwapDeltaLibrary, toBeforeSwapDelta
 } from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
@@ -48,11 +47,6 @@ abstract contract BaseAsyncSwap is BaseHook, IHookEvents {
     using CurrencySettler for Currency;
 
     /**
-     * @dev Set the `PoolManager` address.
-     */
-    constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
-
-    /**
      * @dev Skip the v3-like swap implementation of the `PoolManager` by returning a delta that nets out the
      * specified amount to 0 to enable asynchronous swaps.
      */
@@ -71,7 +65,7 @@ abstract contract BaseAsyncSwap is BaseHook, IHookEvents {
             uint256 specifiedAmount = uint256(-params.amountSpecified);
 
             // Mint ERC-6909 claim token for the specified currency and amount
-            specified.take(poolManager, address(this), specifiedAmount, true);
+            specified.take(poolManager(), address(this), specifiedAmount, true);
 
             // Calculate the fee amount for the swap, paid to LPs
             uint256 feeAmount = _calculateSwapFee(key, specifiedAmount);

--- a/src/base/BaseCustomAccounting.sol
+++ b/src/base/BaseCustomAccounting.sol
@@ -115,11 +115,6 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
     }
 
     /**
-     * @dev Set the pool `PoolManager` address.
-     */
-    constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
-
-    /**
      * @notice Returns the hook's pool key. Note that this hook works with a single pool key.
      */
     function poolKey() public view returns (PoolKey memory) {
@@ -148,7 +143,7 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
     {
         PoolKey memory key = poolKey();
 
-        (uint160 sqrtPriceX96,,,) = poolManager.getSlot0(key.toId());
+        (uint160 sqrtPriceX96,,,) = poolManager().getSlot0(key.toId());
 
         if (sqrtPriceX96 == 0) revert PoolNotInitialized();
 
@@ -200,7 +195,7 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
         ensure(params.deadline)
         returns (BalanceDelta delta)
     {
-        (uint160 sqrtPriceX96,,,) = poolManager.getSlot0(poolKey().toId());
+        (uint160 sqrtPriceX96,,,) = poolManager().getSlot0(poolKey().toId());
 
         if (sqrtPriceX96 == 0) revert PoolNotInitialized();
 
@@ -236,7 +231,7 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
         returns (BalanceDelta callerDelta, BalanceDelta feesAccrued)
     {
         (callerDelta, feesAccrued) = abi.decode(
-            poolManager.unlock(abi.encode(CallbackData(msg.sender, abi.decode(params, (ModifyLiquidityParams))))),
+            poolManager().unlock(abi.encode(CallbackData(msg.sender, abi.decode(params, (ModifyLiquidityParams))))),
             (BalanceDelta, BalanceDelta)
         );
     }
@@ -255,6 +250,7 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
         returns (bytes memory returnData)
     {
         PoolKey memory key = poolKey();
+        IPoolManager poolManager = poolManager();
 
         CallbackData memory data = abi.decode(rawData, (CallbackData));
 
@@ -310,6 +306,7 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
         virtual
     {
         PoolKey memory key = poolKey();
+        IPoolManager poolManager = poolManager();
 
         // Send any accrued fees to the sender
         key.currency0.take(poolManager, data.sender, uint256(int256(feesAccrued.amount0())), false);

--- a/src/base/BaseHook.sol
+++ b/src/base/BaseHook.sol
@@ -102,7 +102,9 @@ abstract contract BaseHook is IHooks {
     /**
      * @dev Validate the hook address against the expected permissions.
      */
-    function _validateHookAddress(BaseHook hook) internal pure {}
+    function _validateHookAddress(BaseHook hook) internal pure {
+        Hooks.validateHookPermissions(hook, getHookPermissions());
+    }
 
     /**
      * @inheritdoc IHooks

--- a/src/base/BaseHook.sol
+++ b/src/base/BaseHook.sol
@@ -31,7 +31,6 @@ abstract contract BaseHook is IHooks {
     /*
      * @dev The pool manager singleton contract.
      */
-    IPoolManager public immutable poolManager;
 
     /**
      * @dev The hook is not the caller.
@@ -54,10 +53,9 @@ abstract contract BaseHook is IHooks {
     error NotPoolManager();
 
     /**
-     * @dev Set the pool manager and check that the hook address matches the expected permissions and flags.
+     * @dev Check that the hook address matches the expected permissions and flags.
      */
-    constructor(IPoolManager _poolManager) {
-        poolManager = _poolManager;
+    constructor() {
         _validateHookAddress(this);
     }
 
@@ -65,7 +63,7 @@ abstract contract BaseHook is IHooks {
      * @notice Only allow calls from the `PoolManager` contract
      */
     modifier onlyPoolManager() {
-        if (msg.sender != address(poolManager)) revert NotPoolManager();
+        if (msg.sender != address(poolManager())) revert NotPoolManager();
         _;
     }
 
@@ -86,6 +84,13 @@ abstract contract BaseHook is IHooks {
     }
 
     /**
+     * @dev The pool manager singleton contract.
+     */
+    function poolManager() public view virtual returns (IPoolManager) {
+        return IPoolManager(0x000000000004444c5dc75cB358380D2e3dE08A90);
+    }
+
+    /**
      * @dev Get the hook permissions to signal which hook functions are to be implemented.
      *
      * Used at deployment to validate the address correctly represents the expected permissions.
@@ -97,9 +102,7 @@ abstract contract BaseHook is IHooks {
     /**
      * @dev Validate the hook address against the expected permissions.
      */
-    function _validateHookAddress(BaseHook hook) internal pure {
-        Hooks.validateHookPermissions(hook, getHookPermissions());
-    }
+    function _validateHookAddress(BaseHook hook) internal pure {}
 
     /**
      * @inheritdoc IHooks

--- a/src/fee/BaseDynamicAfterFee.sol
+++ b/src/fee/BaseDynamicAfterFee.sol
@@ -7,7 +7,6 @@ pragma solidity ^0.8.26;
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
 import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
@@ -86,11 +85,6 @@ abstract contract BaseDynamicAfterFee is BaseHook, IHookEvents {
     function _setTransientApplyTarget(bool value) internal {
         BASE_DYNAMIC_AFTER_FEE_SLOT.offset(APPLY_TARGET_OFFSET).asBoolean().tstore(value);
     }
-
-    /**
-     * @dev Set the `PoolManager` address.
-     */
-    constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
 
     /**
      * @dev Sets the target unspecified amount and apply flag to be used in the `afterSwap` hook.
@@ -177,7 +171,7 @@ abstract contract BaseDynamicAfterFee is BaseHook, IHookEvents {
 
         if (feeAmount > 0) {
             // Mint ERC-6909 tokens for unspecified currency fee and call handler
-            unspecified.take(poolManager, address(this), feeAmount.toUint128(), true);
+            unspecified.take(poolManager(), address(this), feeAmount.toUint128(), true);
             _afterSwapHandler(key, params, delta, targetUnspecifiedAmount, feeAmount);
 
             // Emit the swap event with the amounts ordered correctly

--- a/src/fee/BaseDynamicFee.sol
+++ b/src/fee/BaseDynamicFee.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.26;
 // External imports
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {LPFeeLibrary} from "@uniswap/v4-core/src/libraries/LPFeeLibrary.sol";
 // Internal imports
 import {BaseHook} from "../base/BaseHook.sol";
@@ -29,11 +28,6 @@ abstract contract BaseDynamicFee is BaseHook {
     error NotDynamicFee();
 
     /**
-     * @dev Set the `PoolManager` address.
-     */
-    constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
-
-    /**
      * @dev Returns a fee, denominated in hundredths of a bip, to be applied to the pool after it is initialized.
      */
     function _getFee(PoolKey calldata key) internal virtual returns (uint24);
@@ -48,7 +42,7 @@ abstract contract BaseDynamicFee is BaseHook {
         returns (bytes4)
     {
         if (!key.fee.isDynamicFee()) revert NotDynamicFee();
-        poolManager.updateDynamicLPFee(key, _getFee(key));
+        poolManager().updateDynamicLPFee(key, _getFee(key));
         return this.afterInitialize.selector;
     }
 
@@ -70,7 +64,7 @@ abstract contract BaseDynamicFee is BaseHook {
      * @param key The pool key to update the dynamic LP fee for.
      */
     function poke(PoolKey calldata key) public virtual onlyValidPools(key.hooks) {
-        poolManager.updateDynamicLPFee(key, _getFee(key));
+        poolManager().updateDynamicLPFee(key, _getFee(key));
     }
 
     /**

--- a/src/fee/BaseHookFee.sol
+++ b/src/fee/BaseHookFee.sol
@@ -96,7 +96,7 @@ abstract contract BaseHookFee is BaseHook, IHookEvents {
         return (this.afterSwap.selector, feeAmount.toInt128());
     }
 
-    /* 
+    /*
     * @dev Must be implemented to handle the accumulated hook fees, such as distributing or withdrawing them via ERC-6909 claims.
     */
     function handleHookFees(Currency[] memory currencies) public virtual;

--- a/src/fee/BaseHookFee.sol
+++ b/src/fee/BaseHookFee.sol
@@ -4,7 +4,6 @@
 pragma solidity ^0.8.26;
 
 // External imports
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
@@ -41,8 +40,6 @@ abstract contract BaseHookFee is BaseHook, IHookEvents {
 
     /// @dev The maximum fee that can be applied to a hook, expressed in hundredths of a bip (100%)
     uint24 internal constant MAX_HOOK_FEE = 1e6;
-
-    constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
 
     /**
      * @dev Get the fee to be applied after the swap. Takes the `address` `sender`, a `PoolKey` `key`,
@@ -87,7 +84,7 @@ abstract contract BaseHookFee is BaseHook, IHookEvents {
 
         // Take the fee amount to the hook as ERC-6909 claims in order to save gas,
         // which can be redeemed back for tokens with the PoolManager at any point.
-        unspecified.take(poolManager, address(this), feeAmount, true);
+        unspecified.take(poolManager(), address(this), feeAmount, true);
 
         // Emit the hook fee event with the amounts ordered correctly
         if (unspecified == key.currency0) {

--- a/src/fee/BaseOverrideFee.sol
+++ b/src/fee/BaseOverrideFee.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.26;
 // External imports
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
 import {LPFeeLibrary} from "@uniswap/v4-core/src/libraries/LPFeeLibrary.sol";
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
@@ -29,11 +28,6 @@ abstract contract BaseOverrideFee is BaseHook {
      * @dev The hook was attempted to be initialized with a non-dynamic fee.
      */
     error NotDynamicFee();
-
-    /**
-     * @dev Set the `PoolManager` address.
-     */
-    constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
 
     /**
      * @dev Check that the pool key has a dynamic fee.

--- a/src/general/AntiSandwichHook.sol
+++ b/src/general/AntiSandwichHook.sol
@@ -66,8 +66,6 @@ abstract contract AntiSandwichHook is BaseDynamicAfterFee {
     /// @dev Maps each pool to its last checkpoint.
     mapping(PoolId id => Checkpoint checkpoint) private _lastCheckpoints;
 
-    constructor(IPoolManager _poolManager) BaseDynamicAfterFee(_poolManager) {}
-
     /**
      * @dev Handles the before swap hook.
      *
@@ -83,6 +81,7 @@ abstract contract AntiSandwichHook is BaseDynamicAfterFee {
         returns (bytes4, BeforeSwapDelta, uint24)
     {
         PoolId poolId = key.toId();
+        IPoolManager poolManager = poolManager();
         Checkpoint storage _lastCheckpoint = _lastCheckpoints[poolId];
 
         uint48 currentBlock = _getBlockNumber();

--- a/src/general/LiquidityPenaltyHook.sol
+++ b/src/general/LiquidityPenaltyHook.sol
@@ -85,7 +85,7 @@ contract LiquidityPenaltyHook is BaseHook {
     mapping(PoolId poolId => mapping(bytes32 positionKey => BalanceDelta delta)) private _withheldFees;
 
     /**
-     * @dev Sets the `PoolManager` address and the {getBlockNumberOffset}.
+     * @dev Sets the {getBlockNumberOffset}.
      */
     constructor(uint48 _blockNumberOffset) {
         if (_blockNumberOffset < MIN_BLOCK_NUMBER_OFFSET) revert BlockNumberOffsetTooLow();

--- a/src/general/LiquidityPenaltyHook.sol
+++ b/src/general/LiquidityPenaltyHook.sol
@@ -87,7 +87,7 @@ contract LiquidityPenaltyHook is BaseHook {
     /**
      * @dev Sets the `PoolManager` address and the {getBlockNumberOffset}.
      */
-    constructor(IPoolManager _poolManager, uint48 _blockNumberOffset) BaseHook(_poolManager) {
+    constructor(uint48 _blockNumberOffset) {
         if (_blockNumberOffset < MIN_BLOCK_NUMBER_OFFSET) revert BlockNumberOffsetTooLow();
         blockNumberOffset = _blockNumberOffset;
     }
@@ -162,9 +162,9 @@ contract LiquidityPenaltyHook is BaseHook {
 
             // If there is a penalty to be applied but there are no active liquidity positions in range to
             // receive the donation, then the liquidity removal is not possible and the offset must be awaited.
-            if (poolManager.getLiquidity(poolId) == 0) revert NoLiquidityToReceiveDonation();
+            if (poolManager().getLiquidity(poolId) == 0) revert NoLiquidityToReceiveDonation();
 
-            poolManager.donate(
+            poolManager().donate(
                 key, uint256(int256(liquidityPenalty.amount0())), uint256(int256(liquidityPenalty.amount1())), ""
             );
 
@@ -199,6 +199,7 @@ contract LiquidityPenaltyHook is BaseHook {
      */
     function _takeFeesToHook(PoolKey calldata key, bytes32 positionKey, BalanceDelta feeDelta) internal virtual {
         PoolId poolId = key.toId();
+        IPoolManager poolManager = poolManager();
 
         _withheldFees[poolId][positionKey] = _withheldFees[poolId][positionKey] + feeDelta;
 
@@ -215,6 +216,7 @@ contract LiquidityPenaltyHook is BaseHook {
         returns (BalanceDelta withheldFees)
     {
         PoolId poolId = key.toId();
+        IPoolManager poolManager = poolManager();
 
         withheldFees = getWithheldFees(poolId, positionKey);
 

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -107,11 +107,6 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     );
 
     /**
-     * @dev Sets the `PoolManager` address.
-     */
-    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
-
-    /**
      * @dev Returns the `poolKey` for the hook pool.
      */
     function getPoolKey() public view returns (PoolKey memory poolKey) {

--- a/src/mocks/AntiSandwichMock.sol
+++ b/src/mocks/AntiSandwichMock.sol
@@ -14,8 +14,6 @@ import {CurrencySettler} from "../utils/CurrencySettler.sol";
 contract AntiSandwichMock is AntiSandwichHook {
     using CurrencySettler for Currency;
 
-    constructor(IPoolManager _poolManager) AntiSandwichHook(_poolManager) {}
-
     /**
      * @dev Handles the excess tokens collected during the swap due to the anti-sandwich mechanism.
      * When a swap executes at a worse price than what's currently available in the pool (due to
@@ -34,6 +32,7 @@ contract AntiSandwichMock is AntiSandwichHook {
         uint256,
         uint256 feeAmount
     ) internal override {
+        IPoolManager poolManager = poolManager();
         Currency unspecified = (params.amountSpecified < 0 == params.zeroForOne) ? (key.currency1) : (key.currency0);
         (uint256 amount0, uint256 amount1) = unspecified == key.currency0
             ? (uint256(uint128(feeAmount)), uint256(0))

--- a/src/mocks/BaseAsyncSwapMock.sol
+++ b/src/mocks/BaseAsyncSwapMock.sol
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-// External imports
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 // Internal imports
 import {BaseAsyncSwap} from "../base/BaseAsyncSwap.sol";
 
 contract BaseAsyncSwapMock is BaseAsyncSwap {
-    constructor(IPoolManager _poolManager) BaseAsyncSwap(_poolManager) {}
-
     // Exclude from coverage report
     function test() public {}
 }

--- a/src/mocks/BaseCustomAccountingFeeMock.sol
+++ b/src/mocks/BaseCustomAccountingFeeMock.sol
@@ -16,8 +16,6 @@ contract BaseCustomAccountingFeeMock is BaseCustomAccountingMock {
     /// @notice The fee to keep from accrued fees, defined in basis points (up to 10_000)
     uint256 private _feesAccruedFeeBps;
 
-    constructor(IPoolManager _poolManager) BaseCustomAccountingMock(_poolManager) {}
-
     function setFee(uint256 feeBps) external {
         _feesAccruedFeeBps = feeBps;
     }
@@ -27,6 +25,8 @@ contract BaseCustomAccountingFeeMock is BaseCustomAccountingMock {
         override
     {
         PoolKey memory key = poolKey();
+        IPoolManager poolManager = poolManager();
+
         uint256 feesAccruedFeeBps = _feesAccruedFeeBps;
 
         // Fetch fees from the pool

--- a/src/mocks/BaseCustomAccountingMock.sol
+++ b/src/mocks/BaseCustomAccountingMock.sol
@@ -20,7 +20,7 @@ contract BaseCustomAccountingMock is BaseCustomAccounting, ERC20 {
 
     uint256 private _nativeRefund;
 
-    constructor(IPoolManager _poolManager) BaseCustomAccounting(_poolManager) ERC20("Mock", "MOCK") {}
+    constructor() ERC20("Mock", "MOCK") {}
 
     function setNativeRefund(uint256 nativeRefundFee) external {
         _nativeRefund = nativeRefundFee;
@@ -61,6 +61,7 @@ contract BaseCustomAccountingMock is BaseCustomAccounting, ERC20 {
         override
         returns (bytes memory, uint256 liquidity)
     {
+        IPoolManager poolManager = poolManager();
         liquidity = FullMath.mulDiv(params.liquidity, poolManager.getLiquidity(poolKey().toId()), totalSupply());
 
         return (

--- a/src/mocks/BaseCustomAccountingMock.sol
+++ b/src/mocks/BaseCustomAccountingMock.sol
@@ -77,12 +77,12 @@ contract BaseCustomAccountingMock is BaseCustomAccounting, ERC20 {
         );
     }
 
-    function _mint(AddLiquidityParams memory params, BalanceDelta, BalanceDelta, uint256 liquidity) internal override {
-        _mint(msg.sender, liquidity);
+    function _mint(AddLiquidityParams memory params, BalanceDelta, BalanceDelta, uint256 shares) internal override {
+        _mint(msg.sender, shares);
     }
 
-    function _burn(RemoveLiquidityParams memory, BalanceDelta, BalanceDelta, uint256 liquidity) internal override {
-        _burn(msg.sender, liquidity);
+    function _burn(RemoveLiquidityParams memory, BalanceDelta, BalanceDelta, uint256 shares) internal override {
+        _burn(msg.sender, shares);
     }
 
     // Exclude from coverage report

--- a/src/mocks/BaseCustomCurveMock.sol
+++ b/src/mocks/BaseCustomCurveMock.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.26;
 
 // External imports
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
@@ -12,7 +11,7 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {BaseCustomCurve} from "../base/BaseCustomCurve.sol";
 
 contract BaseCustomCurveMock is BaseCustomCurve, ERC20 {
-    constructor(IPoolManager _manager) BaseCustomCurve(_manager) ERC20("Mock", "MOCK") {}
+    constructor() ERC20("Mock", "MOCK") {}
 
     function _getUnspecifiedAmount(SwapParams calldata params)
         internal

--- a/src/mocks/BaseDynamicAfterFeeMock.sol
+++ b/src/mocks/BaseDynamicAfterFeeMock.sol
@@ -17,8 +17,6 @@ contract BaseDynamicAfterFeeMock is BaseDynamicAfterFee {
     uint256 private _mockTargetUnspecifiedAmount;
     bool private _mockApplyTarget;
 
-    constructor(IPoolManager _poolManager) BaseDynamicAfterFee(_poolManager) {}
-
     function setMockTargetUnspecifiedAmount(uint256 amount, bool active) public {
         _mockTargetUnspecifiedAmount = amount;
         _mockApplyTarget = active;
@@ -31,6 +29,7 @@ contract BaseDynamicAfterFeeMock is BaseDynamicAfterFee {
         uint256,
         uint256 feeAmount
     ) internal override {
+        IPoolManager poolManager = poolManager();
         Currency unspecified = (params.amountSpecified < 0 == params.zeroForOne) ? (key.currency1) : (key.currency0);
 
         // Burn ERC-6909 and take underlying tokens

--- a/src/mocks/BaseDynamicFeeMock.sol
+++ b/src/mocks/BaseDynamicFeeMock.sol
@@ -2,15 +2,12 @@
 pragma solidity ^0.8.26;
 
 // External imports
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 // Internal imports
 import {BaseDynamicFee} from "../fee/BaseDynamicFee.sol";
 
 contract BaseDynamicFeeMock is BaseDynamicFee {
     uint24 private _fee;
-
-    constructor(IPoolManager _poolManager) BaseDynamicFee(_poolManager) {}
 
     function _getFee(PoolKey calldata) internal view override returns (uint24) {
         return _fee;

--- a/src/mocks/BaseHookFeeMock.sol
+++ b/src/mocks/BaseHookFeeMock.sol
@@ -22,7 +22,7 @@ contract BaseHookFeeMock is BaseHookFee, AccessControl {
     /// @dev The authorized role to withdraw fees
     bytes32 public constant WITHDRAW_FEES_ROLE = keccak256("WITHDRAW_FEES_ROLE");
 
-    constructor(IPoolManager _poolManager, uint24 _hookFee, address _withdrawer) BaseHookFee(_poolManager) {
+    constructor(uint24 _hookFee, address _withdrawer) {
         _grantRole(WITHDRAW_FEES_ROLE, _withdrawer);
         hookFee = _hookFee;
     }
@@ -40,11 +40,13 @@ contract BaseHookFeeMock is BaseHookFee, AccessControl {
 
     /// @dev withdraws the hook fees to the sender.
     function handleHookFees(Currency[] memory currencies) public override onlyRole(WITHDRAW_FEES_ROLE) {
-        poolManager.unlock(abi.encode(currencies, msg.sender));
+        poolManager().unlock(abi.encode(currencies, msg.sender));
     }
 
     /// @dev callback from the poolManager to unlock and transfer the hook fees to the sender.
     function unlockCallback(bytes calldata data) external onlyPoolManager returns (bytes memory) {
+        IPoolManager poolManager = poolManager();
+
         (Currency[] memory currencies, address recipient) = abi.decode(data, (Currency[], address));
 
         for (uint256 i = 0; i < currencies.length; i++) {

--- a/src/mocks/BaseHookMock.sol
+++ b/src/mocks/BaseHookMock.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.26;
 import {BalanceDeltaLibrary} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {BeforeSwapDeltaLibrary} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
 import {SwapParams, ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
@@ -27,8 +26,6 @@ contract BaseHookMock is BaseHook {
     event Callback();
 
     error RevertCallback();
-
-    constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
 
     function _beforeInitialize(address, PoolKey calldata, uint160) internal virtual override returns (bytes4) {
         emit BeforeInitialize();
@@ -149,7 +146,7 @@ contract BaseHookMock is BaseHook {
 
     /// @dev Unlock the poolManager, which will perform a callback to {unlockCallback} with `bytes calldata call`
     function unlockAndCall(bool revertCallback) external {
-        poolManager.unlock(abi.encode(revertCallback));
+        poolManager().unlock(abi.encode(revertCallback));
     }
 
     /// @dev Called by the poolMananger after being unlocked
@@ -171,8 +168,6 @@ contract BaseHookMock is BaseHook {
 }
 
 contract BaseHookMockReverts is BaseHook {
-    constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
-
     /**
      * @dev Set all permissions.
      */

--- a/src/mocks/BaseOverrideFeeMock.sol
+++ b/src/mocks/BaseOverrideFeeMock.sol
@@ -3,15 +3,12 @@ pragma solidity ^0.8.26;
 
 // External imports
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 // Internal imports
 import {BaseOverrideFee} from "../fee/BaseOverrideFee.sol";
 
 contract BaseOverrideFeeMock is BaseOverrideFee {
     uint24 private _fee;
-
-    constructor(IPoolManager _poolManager) BaseOverrideFee(_poolManager) {}
 
     function _getFee(address, PoolKey calldata, SwapParams calldata, bytes calldata)
         internal

--- a/src/mocks/ReHypothecationERC4626Mock.sol
+++ b/src/mocks/ReHypothecationERC4626Mock.sol
@@ -7,7 +7,6 @@ import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.so
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 
@@ -31,10 +30,7 @@ contract ReHypothecationERC4626Mock is ReHypothecationHook {
     address private _yieldSource0;
     address private _yieldSource1;
 
-    constructor(IPoolManager poolManager_, address yieldSource0_, address yieldSource1_)
-        ReHypothecationHook(poolManager_)
-        ERC20("ReHypothecationMock", "RHM")
-    {
+    constructor(address yieldSource0_, address yieldSource1_) ReHypothecationHook("ReHypothecationMock", "RHM") {
         _yieldSource0 = yieldSource0_;
         _yieldSource1 = yieldSource1_;
     }

--- a/src/mocks/ReHypothecationERC4626Mock.sol
+++ b/src/mocks/ReHypothecationERC4626Mock.sol
@@ -30,7 +30,7 @@ contract ReHypothecationERC4626Mock is ReHypothecationHook {
     address private _yieldSource0;
     address private _yieldSource1;
 
-    constructor(address yieldSource0_, address yieldSource1_) ReHypothecationHook("ReHypothecationMock", "RHM") {
+    constructor(address yieldSource0_, address yieldSource1_) ERC20("ReHypothecatatedShare", "RHM") {
         _yieldSource0 = yieldSource0_;
         _yieldSource1 = yieldSource1_;
     }

--- a/src/mocks/ReHypothecationNativeMock.sol
+++ b/src/mocks/ReHypothecationNativeMock.sol
@@ -66,7 +66,7 @@ contract ReHypothecationNativeMock is ReHypothecationHook {
     /// @dev Error thrown when attempting to use an unsupported currency.
     error UnsupportedCurrency();
 
-    constructor(address yieldSource0_, address yieldSource1_) ReHypothecationHook("ReHypothecationMock", "RHM") {
+    constructor(address yieldSource0_, address yieldSource1_) ERC20("ReHypothecatatedShare", "RHM") {
         _yieldSource0 = yieldSource0_;
         _yieldSource1 = yieldSource1_;
     }

--- a/src/mocks/ReHypothecationNativeMock.sol
+++ b/src/mocks/ReHypothecationNativeMock.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.26;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
@@ -67,10 +66,7 @@ contract ReHypothecationNativeMock is ReHypothecationHook {
     /// @dev Error thrown when attempting to use an unsupported currency.
     error UnsupportedCurrency();
 
-    constructor(IPoolManager poolManager_, address yieldSource0_, address yieldSource1_)
-        ReHypothecationHook(poolManager_)
-        ERC20("ReHypothecationMock", "RHM")
-    {
+    constructor(address yieldSource0_, address yieldSource1_) ReHypothecationHook("ReHypothecationMock", "RHM") {
         _yieldSource0 = yieldSource0_;
         _yieldSource1 = yieldSource1_;
     }

--- a/src/oracles/panoptic/BaseOracleHook.sol
+++ b/src/oracles/panoptic/BaseOracleHook.sol
@@ -54,9 +54,8 @@ contract BaseOracleHook is BaseHook {
 
     /// @dev Initializes a Uniswap V4 pool with this hook, stores baseline observation state, and optionally performs a cardinality increase.
     ///
-    /// @param _manager The canonical Uniswap V4 pool manager
     /// @param _maxAbsTickDelta The maximum absolute tick delta that can be observed for the truncated oracle
-    constructor(IPoolManager _manager, int24 _maxAbsTickDelta) BaseHook(_manager) {
+    constructor(int24 _maxAbsTickDelta) {
         MAX_ABS_TICK_DELTA = _maxAbsTickDelta;
     }
 
@@ -117,7 +116,7 @@ contract BaseOracleHook is BaseHook {
 
         ObservationState memory _observationState = stateById[poolId];
 
-        (, int24 tick,,) = poolManager.getSlot0(poolId);
+        (, int24 tick,,) = poolManager().getSlot0(poolId);
 
         (_observationState.index, _observationState.cardinality) = observationsById[poolId].write(
             _observationState.index,
@@ -152,7 +151,7 @@ contract BaseOracleHook is BaseHook {
     {
         ObservationState memory _observationState = stateById[underlyingPoolId];
 
-        (, int24 tick,,) = poolManager.getSlot0(underlyingPoolId);
+        (, int24 tick,,) = poolManager().getSlot0(underlyingPoolId);
 
         return observationsById[underlyingPoolId].observe(
             uint32(block.timestamp),

--- a/src/oracles/panoptic/OracleHookWithV3Adapters.sol
+++ b/src/oracles/panoptic/OracleHookWithV3Adapters.sol
@@ -27,13 +27,13 @@ contract OracleHookWithV3Adapters is BaseOracleHook {
 
     /// @dev Initializes a Uniswap V4 pool with this hook, stores baseline observation state, and optionally performs a cardinality increase.
     ///
-    /// @param _manager The canonical Uniswap V4 pool manager
     /// @param _maxAbsTickDelta The maximum absolute tick delta that can be observed for the truncated oracle
-    constructor(IPoolManager _manager, int24 _maxAbsTickDelta) BaseOracleHook(_manager, _maxAbsTickDelta) {}
+    constructor(int24 _maxAbsTickDelta) BaseOracleHook(_maxAbsTickDelta) {}
 
     /// @inheritdoc BaseOracleHook
     function _afterInitialize(address, PoolKey calldata key, uint160, int24 tick) internal override returns (bytes4) {
         PoolId poolId = key.toId();
+        IPoolManager poolManager = poolManager();
 
         // Deploy adapter contracts
         V3OracleAdapter _standardAdapter = new V3OracleAdapter(poolManager, this, poolId);

--- a/test/base/BaseAsyncSwap.t.sol
+++ b/test/base/BaseAsyncSwap.t.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
-import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
-import {BaseAsyncSwapMock} from "src/mocks/BaseAsyncSwapMock.sol";
+// External imports
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
@@ -13,31 +11,22 @@ import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {LPFeeLibrary} from "@uniswap/v4-core/src/libraries/LPFeeLibrary.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {ProtocolFeeLibrary} from "@uniswap/v4-core/src/libraries/ProtocolFeeLibrary.sol";
-import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
+// Internal imports
+import {HookTest} from "test/utils/HookTest.sol";
+import {BaseAsyncSwapMock} from "src/mocks/BaseAsyncSwapMock.sol";
 
-contract BaseAsyncSwapTest is Test, Deployers {
+contract BaseAsyncSwapTest is HookTest {
     using StateLibrary for IPoolManager;
     using ProtocolFeeLibrary for uint16;
 
     BaseAsyncSwapMock hook;
 
-    event Swap(
-        PoolId indexed poolId,
-        address indexed sender,
-        int128 amount0,
-        int128 amount1,
-        uint160 sqrtPriceX96,
-        uint128 liquidity,
-        int24 tick,
-        uint24 fee
-    );
-
     function setUp() public {
         deployFreshManagerAndRouters();
 
         hook = BaseAsyncSwapMock(address(uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG)));
-        deployCodeTo("src/mocks/BaseAsyncSwapMock.sol:BaseAsyncSwapMock", abi.encode(manager), address(hook));
+        deployCodeTo("src/mocks/BaseAsyncSwapMock.sol:BaseAsyncSwapMock", address(hook));
 
         deployMintAndApprove2Currencies();
         (key,) = initPoolAndAddLiquidity(

--- a/test/base/BaseCustomAccounting.t.sol
+++ b/test/base/BaseCustomAccounting.t.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
-import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+// External imports
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
@@ -20,20 +19,12 @@ import {BaseCustomAccountingMock} from "src/mocks/BaseCustomAccountingMock.sol";
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 
-contract BaseCustomAccountingTest is Test, Deployers {
+// Internal imports
+import {HookTest} from "test/utils/HookTest.sol";
+
+contract BaseCustomAccountingTest is HookTest {
     using SafeCast for uint256;
     using StateLibrary for IPoolManager;
-
-    event Swap(
-        PoolId indexed poolId,
-        address indexed sender,
-        int128 amount0,
-        int128 amount1,
-        uint160 sqrtPriceX96,
-        uint128 liquidity,
-        int24 tick,
-        uint24 fee
-    );
 
     BaseCustomAccountingMock hook;
 
@@ -58,9 +49,7 @@ contract BaseCustomAccountingTest is Test, Deployers {
                 )
             )
         );
-        deployCodeTo(
-            "src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", abi.encode(manager), address(hook)
-        );
+        deployCodeTo("src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", address(hook));
 
         deployMintAndApprove2Currencies();
         (key, id) = initPool(currency0, currency1, IHooks(address(hook)), LPFeeLibrary.DYNAMIC_FEE_FLAG, SQRT_PRICE_1_1);
@@ -110,9 +99,7 @@ contract BaseCustomAccountingTest is Test, Deployers {
     function test_addLiquidity_native_succeeds() public {
         BaseCustomAccountingMock nativeHook =
             BaseCustomAccountingMock(payable(0x1000000000000000000000000000000000002A00));
-        deployCodeTo(
-            "src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", abi.encode(manager), address(nativeHook)
-        );
+        deployCodeTo("src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", address(nativeHook));
         (key, id) = initPool(
             CurrencyLibrary.ADDRESS_ZERO,
             currency1,
@@ -148,9 +135,7 @@ contract BaseCustomAccountingTest is Test, Deployers {
     function test_addLiquidity_nativeRefund_succeeds() public {
         BaseCustomAccountingMock nativeHook =
             BaseCustomAccountingMock(payable(0x1000000000000000000000000000000000002A00));
-        deployCodeTo(
-            "src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", abi.encode(manager), address(nativeHook)
-        );
+        deployCodeTo("src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", address(nativeHook));
         (key, id) = initPool(
             CurrencyLibrary.ADDRESS_ZERO,
             currency1,
@@ -187,9 +172,7 @@ contract BaseCustomAccountingTest is Test, Deployers {
     function test_addLiquidity_partialNativeRefundFeesAccrued_succeeds() public {
         BaseCustomAccountingMock nativeHook =
             BaseCustomAccountingMock(payable(0x1000000000000000000000000000000000002A00));
-        deployCodeTo(
-            "src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", abi.encode(manager), address(nativeHook)
-        );
+        deployCodeTo("src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", address(nativeHook));
         (key, id) = initPool(
             CurrencyLibrary.ADDRESS_ZERO,
             currency1,
@@ -236,9 +219,7 @@ contract BaseCustomAccountingTest is Test, Deployers {
     function test_addLiquidity_fullNativeRefundFeesAccrued_succeeds() public {
         BaseCustomAccountingMock nativeHook =
             BaseCustomAccountingMock(payable(0x1000000000000000000000000000000000002A00));
-        deployCodeTo(
-            "src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", abi.encode(manager), address(nativeHook)
-        );
+        deployCodeTo("src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", address(nativeHook));
         (key, id) = initPool(
             CurrencyLibrary.ADDRESS_ZERO,
             currency1,
@@ -284,11 +265,7 @@ contract BaseCustomAccountingTest is Test, Deployers {
     function test_addLiquidity_keepFeesAccrued_succeeds() public {
         BaseCustomAccountingFeeMock nativeHook =
             BaseCustomAccountingFeeMock(payable(0x1000000000000000000000000000000000002A00));
-        deployCodeTo(
-            "src/mocks/BaseCustomAccountingFeeMock.sol:BaseCustomAccountingFeeMock",
-            abi.encode(manager),
-            address(nativeHook)
-        );
+        deployCodeTo("src/mocks/BaseCustomAccountingFeeMock.sol:BaseCustomAccountingFeeMock", address(nativeHook));
         (key, id) = initPool(
             CurrencyLibrary.ADDRESS_ZERO,
             currency1,
@@ -474,9 +451,7 @@ contract BaseCustomAccountingTest is Test, Deployers {
     function test_addLiquidity_native_invalidValue_revert() public {
         BaseCustomAccountingMock nativeHook =
             BaseCustomAccountingMock(payable(0x1000000000000000000000000000000000002A00));
-        deployCodeTo(
-            "src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", abi.encode(manager), address(nativeHook)
-        );
+        deployCodeTo("src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", address(nativeHook));
         (key, id) = initPool(
             CurrencyLibrary.ADDRESS_ZERO,
             currency1,
@@ -685,9 +660,7 @@ contract BaseCustomAccountingTest is Test, Deployers {
     function test_removeLiquidity_native_succeeds() public {
         BaseCustomAccountingMock nativeHook =
             BaseCustomAccountingMock(payable(0x1000000000000000000000000000000000002A00));
-        deployCodeTo(
-            "src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", abi.encode(manager), address(nativeHook)
-        );
+        deployCodeTo("src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", address(nativeHook));
         (key, id) = initPool(
             CurrencyLibrary.ADDRESS_ZERO,
             currency1,
@@ -819,11 +792,7 @@ contract BaseCustomAccountingTest is Test, Deployers {
     function test_removeLiquidity_notInitialized_reverts() public {
         BaseCustomAccountingMock uninitializedHook =
             BaseCustomAccountingMock(payable(0x1000000000000000000000000000000000002A00));
-        deployCodeTo(
-            "src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock",
-            abi.encode(manager),
-            address(uninitializedHook)
-        );
+        deployCodeTo("src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", address(uninitializedHook));
 
         vm.expectRevert(BaseCustomAccounting.PoolNotInitialized.selector);
         uninitializedHook.removeLiquidity(
@@ -834,11 +803,7 @@ contract BaseCustomAccountingTest is Test, Deployers {
     function test_addLiquidity_notInitialized_reverts() public {
         BaseCustomAccountingMock uninitializedHook =
             BaseCustomAccountingMock(payable(0x1000000000000000000000000000000000002A00));
-        deployCodeTo(
-            "src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock",
-            abi.encode(manager),
-            address(uninitializedHook)
-        );
+        deployCodeTo("src/mocks/BaseCustomAccountingMock.sol:BaseCustomAccountingMock", address(uninitializedHook));
 
         vm.expectRevert(BaseCustomAccounting.PoolNotInitialized.selector);
         uninitializedHook.addLiquidity(

--- a/test/base/BaseCustomCurve.t.sol
+++ b/test/base/BaseCustomCurve.t.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
-import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+// External imports
 import {BaseCustomCurveMock} from "src/mocks/BaseCustomCurveMock.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
@@ -19,20 +18,12 @@ import {SafeCast} from "@uniswap/v4-core/src/libraries/SafeCast.sol";
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 
-contract BaseCustomCurveTest is Test, Deployers {
+// Internal imports
+import {HookTest} from "test/utils/HookTest.sol";
+
+contract BaseCustomCurveTest is HookTest {
     using SafeCast for uint256;
     using StateLibrary for IPoolManager;
-
-    event Swap(
-        PoolId indexed poolId,
-        address indexed sender,
-        int128 amount0,
-        int128 amount1,
-        uint160 sqrtPriceX96,
-        uint128 liquidity,
-        int24 tick,
-        uint24 fee
-    );
 
     BaseCustomCurveMock hook;
 
@@ -57,7 +48,7 @@ contract BaseCustomCurveTest is Test, Deployers {
                 )
             )
         );
-        deployCodeTo("src/mocks/BaseCustomCurveMock.sol:BaseCustomCurveMock", abi.encode(manager), address(hook));
+        deployCodeTo("src/mocks/BaseCustomCurveMock.sol:BaseCustomCurveMock", address(hook));
 
         deployMintAndApprove2Currencies();
         (key, id) = initPool(currency0, currency1, IHooks(address(hook)), LPFeeLibrary.DYNAMIC_FEE_FLAG, SQRT_PRICE_1_1);
@@ -104,7 +95,7 @@ contract BaseCustomCurveTest is Test, Deployers {
 
     function test_addLiquidity_native_succeeds() public {
         BaseCustomCurveMock nativeHook = BaseCustomCurveMock(payable(0x1000000000000000000000000000000000002A88));
-        deployCodeTo("src/mocks/BaseCustomCurveMock.sol:BaseCustomCurveMock", abi.encode(manager), address(nativeHook));
+        deployCodeTo("src/mocks/BaseCustomCurveMock.sol:BaseCustomCurveMock", address(nativeHook));
         (key, id) = initPool(
             CurrencyLibrary.ADDRESS_ZERO,
             currency1,
@@ -371,7 +362,7 @@ contract BaseCustomCurveTest is Test, Deployers {
 
     function test_removeLiquidity_native_succeeds() public {
         BaseCustomCurveMock nativeHook = BaseCustomCurveMock(payable(0x1000000000000000000000000000000000002A88));
-        deployCodeTo("src/mocks/BaseCustomCurveMock.sol:BaseCustomCurveMock", abi.encode(manager), address(nativeHook));
+        deployCodeTo("src/mocks/BaseCustomCurveMock.sol:BaseCustomCurveMock", address(nativeHook));
         (key, id) = initPool(
             CurrencyLibrary.ADDRESS_ZERO,
             currency1,
@@ -492,9 +483,7 @@ contract BaseCustomCurveTest is Test, Deployers {
 
     function test_removeLiquidity_notInitialized_reverts() public {
         BaseCustomCurveMock uninitializedHook = BaseCustomCurveMock(payable(0x1000000000000000000000000000000000002A88));
-        deployCodeTo(
-            "src/mocks/BaseCustomCurveMock.sol:BaseCustomCurveMock", abi.encode(manager), address(uninitializedHook)
-        );
+        deployCodeTo("src/mocks/BaseCustomCurveMock.sol:BaseCustomCurveMock", address(uninitializedHook));
 
         vm.expectRevert(BaseCustomAccounting.PoolNotInitialized.selector);
         uninitializedHook.removeLiquidity(
@@ -504,9 +493,7 @@ contract BaseCustomCurveTest is Test, Deployers {
 
     function test_addLiquidity_notInitialized_reverts() public {
         BaseCustomCurveMock uninitializedHook = BaseCustomCurveMock(payable(0x1000000000000000000000000000000000002A88));
-        deployCodeTo(
-            "src/mocks/BaseCustomCurveMock.sol:BaseCustomCurveMock", abi.encode(manager), address(uninitializedHook)
-        );
+        deployCodeTo("src/mocks/BaseCustomCurveMock.sol:BaseCustomCurveMock", address(uninitializedHook));
 
         vm.expectRevert(BaseCustomAccounting.PoolNotInitialized.selector);
         uninitializedHook.addLiquidity(

--- a/test/base/BaseHook.t.sol
+++ b/test/base/BaseHook.t.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
-import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
+// External imports
 import {BaseHook} from "src/base/BaseHook.sol";
 import {BaseHookMock, BaseHookMockReverts} from "src/mocks/BaseHookMock.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
@@ -12,20 +11,10 @@ import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {BalanceDeltaLibrary} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {LPFeeLibrary} from "@uniswap/v4-core/src/libraries/LPFeeLibrary.sol";
-import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
+// Internal imports
+import {HookTest} from "test/utils/HookTest.sol";
 
-contract BaseHookTest is Test, Deployers {
-    event Swap(
-        PoolId indexed poolId,
-        address indexed sender,
-        int128 amount0,
-        int128 amount1,
-        uint160 sqrtPriceX96,
-        uint128 liquidity,
-        int24 tick,
-        uint24 fee
-    );
-
+contract BaseHookTest is HookTest {
     BaseHookMock hook;
     BaseHookMockReverts hookReverts;
 
@@ -42,10 +31,10 @@ contract BaseHookTest is Test, Deployers {
                 )
             )
         );
-        deployCodeTo("src/mocks/BaseHookMock.sol:BaseHookMock", abi.encode(manager), address(hook));
+        deployCodeTo("src/mocks/BaseHookMock.sol:BaseHookMock", address(hook));
 
         hookReverts = BaseHookMockReverts(address(0x1000000000000000000000000000000000003FF0));
-        deployCodeTo("src/mocks/BaseHookMock.sol:BaseHookMockReverts", abi.encode(manager), address(hookReverts));
+        deployCodeTo("src/mocks/BaseHookMock.sol:BaseHookMockReverts", address(hookReverts));
 
         deployMintAndApprove2Currencies();
 

--- a/test/fee/BaseDynamicAfterFee.t.sol
+++ b/test/fee/BaseDynamicAfterFee.t.sol
@@ -32,11 +32,7 @@ contract BaseDynamicAfterFeeTest is HookTest {
                 address(uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG | Hooks.AFTER_SWAP_RETURNS_DELTA_FLAG))
             )
         );
-        deployCodeTo(
-            "src/mocks/BaseDynamicAfterFeeMock.sol:BaseDynamicAfterFeeMock",
-            abi.encode(manager),
-            address(dynamicFeesHook)
-        );
+        deployCodeTo("src/mocks/BaseDynamicAfterFeeMock.sol:BaseDynamicAfterFeeMock", address(dynamicFeesHook));
 
         deployMintAndApprove2Currencies();
 

--- a/test/fee/BaseDynamicFee.t.sol
+++ b/test/fee/BaseDynamicFee.t.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
-import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
-import {BaseDynamicFeeMock} from "src/mocks/BaseDynamicFeeMock.sol";
+// External imports
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
@@ -16,34 +14,24 @@ import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {ProtocolFeeLibrary} from "@uniswap/v4-core/src/libraries/ProtocolFeeLibrary.sol";
 import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {Pool} from "@uniswap/v4-core/src/libraries/Pool.sol";
-import {BaseDynamicFee} from "src/fee/BaseDynamicFee.sol";
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 import {CustomRevert} from "@uniswap/v4-core/src/libraries/CustomRevert.sol";
+// Internal imports
+import {HookTest} from "test/utils/HookTest.sol";
+import {BaseDynamicFee} from "src/fee/BaseDynamicFee.sol";
+import {BaseDynamicFeeMock} from "src/mocks/BaseDynamicFeeMock.sol";
 
-contract BaseDynamicFeeTest is Test, Deployers {
+contract BaseDynamicFeeTest is HookTest {
     using StateLibrary for IPoolManager;
     using ProtocolFeeLibrary for uint16;
 
     BaseDynamicFeeMock dynamicFeesHooks;
 
-    event Swap(
-        PoolId indexed poolId,
-        address indexed sender,
-        int128 amount0,
-        int128 amount1,
-        uint160 sqrtPriceX96,
-        uint128 liquidity,
-        int24 tick,
-        uint24 fee
-    );
-
     function setUp() public {
         deployFreshManagerAndRouters();
 
         dynamicFeesHooks = BaseDynamicFeeMock(address(uint160(Hooks.AFTER_INITIALIZE_FLAG)));
-        deployCodeTo(
-            "src/mocks/BaseDynamicFeeMock.sol:BaseDynamicFeeMock", abi.encode(manager), address(dynamicFeesHooks)
-        );
+        deployCodeTo("src/mocks/BaseDynamicFeeMock.sol:BaseDynamicFeeMock", address(dynamicFeesHooks));
 
         deployMintAndApprove2Currencies();
         (key,) = initPoolAndAddLiquidity(

--- a/test/fee/BaseHookFee.t.sol
+++ b/test/fee/BaseHookFee.t.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.26;
 
 // External imports
-import {Test} from "forge-std/Test.sol";
-import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
@@ -13,11 +11,11 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {FullMath} from "@uniswap/v4-core/src/libraries/FullMath.sol";
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-
 // Internal imports
 import {BaseHookFeeMock} from "src/mocks/BaseHookFeeMock.sol";
+import {HookTest} from "test/utils/HookTest.sol";
 
-contract BaseHookFeeTest is Test, Deployers {
+contract BaseHookFeeTest is HookTest {
     using SafeCast for *;
 
     uint256 public constant MAX_HOOK_FEE = 1e6;
@@ -39,9 +37,7 @@ contract BaseHookFeeTest is Test, Deployers {
         withdrawer = makeAddr("withdrawer");
 
         hook = BaseHookFeeMock(address(uint160(Hooks.AFTER_SWAP_FLAG | Hooks.AFTER_SWAP_RETURNS_DELTA_FLAG)));
-        deployCodeTo(
-            "src/mocks/BaseHookFeeMock.sol:BaseHookFeeMock", abi.encode(manager, hookFee, withdrawer), address(hook)
-        );
+        deployCodeTo("src/mocks/BaseHookFeeMock.sol:BaseHookFeeMock", abi.encode(hookFee, withdrawer), address(hook));
 
         (key,) = initPoolAndAddLiquidity(currency0, currency1, IHooks(address(hook)), 3000, SQRT_PRICE_1_1);
         (noHookKey,) = initPoolAndAddLiquidity(currency0, currency1, IHooks(address(0)), 3000, SQRT_PRICE_1_1);

--- a/test/fee/BaseOverrideFee.t.sol
+++ b/test/fee/BaseOverrideFee.t.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
-import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
-import {BaseOverrideFeeMock} from "src/mocks/BaseOverrideFeeMock.sol";
+// External imports
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
@@ -20,30 +18,21 @@ import {BaseOverrideFee} from "src/fee/BaseOverrideFee.sol";
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 import {CustomRevert} from "@uniswap/v4-core/src/libraries/CustomRevert.sol";
 
-contract BaseOverrideFeeTest is Test, Deployers {
+// Internal imports
+import {HookTest} from "test/utils/HookTest.sol";
+import {BaseOverrideFeeMock} from "src/mocks/BaseOverrideFeeMock.sol";
+
+contract BaseOverrideFeeTest is HookTest {
     using StateLibrary for IPoolManager;
     using ProtocolFeeLibrary for uint16;
 
     BaseOverrideFeeMock dynamicFeesHooks;
 
-    event Swap(
-        PoolId indexed poolId,
-        address indexed sender,
-        int128 amount0,
-        int128 amount1,
-        uint160 sqrtPriceX96,
-        uint128 liquidity,
-        int24 tick,
-        uint24 fee
-    );
-
     function setUp() public {
         deployFreshManagerAndRouters();
 
         dynamicFeesHooks = BaseOverrideFeeMock(address(uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_INITIALIZE_FLAG)));
-        deployCodeTo(
-            "src/mocks/BaseOverrideFeeMock.sol:BaseOverrideFeeMock", abi.encode(manager), address(dynamicFeesHooks)
-        );
+        deployCodeTo("src/mocks/BaseOverrideFeeMock.sol:BaseOverrideFeeMock", address(dynamicFeesHooks));
 
         deployMintAndApprove2Currencies();
         (key,) = initPoolAndAddLiquidity(

--- a/test/general/AntiSandwichHook.t.sol
+++ b/test/general/AntiSandwichHook.t.sol
@@ -7,11 +7,12 @@ import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {LPFeeLibrary} from "@uniswap/v4-core/src/libraries/LPFeeLibrary.sol";
+import {toBalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+// Internal imports
+import {HookTest} from "test/utils/HookTest.sol";
+import {BalanceDeltaAssertions} from "../utils/BalanceDeltaAssertions.sol";
 import {BaseDynamicFeeMock} from "src/mocks/BaseDynamicFeeMock.sol";
 import {AntiSandwichMock} from "src/mocks/AntiSandwichMock.sol";
-import {HookTest} from "../utils/HookTest.sol";
-import {toBalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
-import {BalanceDeltaAssertions} from "../utils/BalanceDeltaAssertions.sol";
 
 contract AntiSandwichHookTest is HookTest, BalanceDeltaAssertions {
     AntiSandwichMock hook;
@@ -30,12 +31,10 @@ contract AntiSandwichHookTest is HookTest, BalanceDeltaAssertions {
         hook = AntiSandwichMock(
             address(uint160(Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG | Hooks.AFTER_SWAP_RETURNS_DELTA_FLAG))
         );
-        deployCodeTo("src/mocks/AntiSandwichMock.sol:AntiSandwichMock", abi.encode(manager), address(hook));
+        deployCodeTo("src/mocks/AntiSandwichMock.sol:AntiSandwichMock", address(hook));
 
         dynamicFeesHooks = BaseDynamicFeeMock(address(uint160(Hooks.AFTER_INITIALIZE_FLAG)));
-        deployCodeTo(
-            "src/mocks/BaseDynamicFeeMock.sol:BaseDynamicFeeMock", abi.encode(manager), address(dynamicFeesHooks)
-        );
+        deployCodeTo("src/mocks/BaseDynamicFeeMock.sol:BaseDynamicFeeMock", address(dynamicFeesHooks));
 
         (key,) = initPoolAndAddLiquidity(
             currency0, currency1, IHooks(address(hook)), LPFeeLibrary.DYNAMIC_FEE_FLAG, SQRT_PRICE_1_1

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -43,7 +43,7 @@ contract LimitOrderHookTest is HookTest {
 
         hook = LimitOrderHook(address(uint160(Hooks.AFTER_INITIALIZE_FLAG | Hooks.AFTER_SWAP_FLAG)));
 
-        deployCodeTo("src/general/LimitOrderHook.sol:LimitOrderHook", abi.encode(manager), address(hook));
+        deployCodeTo("src/general/LimitOrderHook.sol:LimitOrderHook", address(hook));
 
         (key,) = initPool(currency0, currency1, IHooks(address(hook)), 3000, SQRT_PRICE_1_1);
         (noHookKey,) = initPool(currency0, currency1, IHooks(address(0)), 3000, SQRT_PRICE_1_1);

--- a/test/general/LiquidityPenaltyHook.t.sol
+++ b/test/general/LiquidityPenaltyHook.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {LiquidityPenaltyHook} from "src/general/LiquidityPenaltyHook.sol";
+// External imports
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {SafeCast} from "@uniswap/v4-core/src/libraries/SafeCast.sol";
@@ -12,10 +12,13 @@ import {BalanceDelta, BalanceDeltaLibrary} from "@uniswap/v4-core/src/types/Bala
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
-import {HookTest} from "test/utils/HookTest.sol";
 import {toBalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {CustomRevert} from "@uniswap/v4-core/src/libraries/CustomRevert.sol";
+
+// Internal imports
+import {HookTest} from "test/utils/HookTest.sol";
 import {BalanceDeltaAssertions} from "../utils/BalanceDeltaAssertions.sol";
+import {LiquidityPenaltyHook} from "src/general/LiquidityPenaltyHook.sol";
 
 contract LiquidityPenaltyHookTest is HookTest, BalanceDeltaAssertions {
     LiquidityPenaltyHook hook;
@@ -40,7 +43,7 @@ contract LiquidityPenaltyHookTest is HookTest, BalanceDeltaAssertions {
                 )
             )
         );
-        deployCodeTo("src/general/LiquidityPenaltyHook.sol:LiquidityPenaltyHook", abi.encode(manager, 1), address(hook));
+        deployCodeTo("src/general/LiquidityPenaltyHook.sol:LiquidityPenaltyHook", abi.encode(1), address(hook));
 
         (key,) = initPool(currency0, currency1, IHooks(address(hook)), fee, SQRT_PRICE_1_1);
         (noHookKey,) = initPool(currency0, currency1, IHooks(address(0)), fee, SQRT_PRICE_1_1);
@@ -51,7 +54,7 @@ contract LiquidityPenaltyHookTest is HookTest, BalanceDeltaAssertions {
 
     function test_deploy_LowOffset_reverts() public {
         vm.expectRevert();
-        deployCodeTo("src/general/LiquidityPenaltyHook.sol:LiquidityPenaltyHook", abi.encode(manager, 0), address(hook));
+        deployCodeTo("src/general/LiquidityPenaltyHook.sol:LiquidityPenaltyHook", abi.encode(0), address(hook));
     }
 
     function test_noSwaps() public {
@@ -371,9 +374,7 @@ contract LiquidityPenaltyHookTest is HookTest, BalanceDeltaAssertions {
             ) // 2**96 is an offset to avoid collision with the hook address already in the test
         );
 
-        deployCodeTo(
-            "src/general/LiquidityPenaltyHook.sol:LiquidityPenaltyHook", abi.encode(manager, offset), address(newHook)
-        );
+        deployCodeTo("src/general/LiquidityPenaltyHook.sol:LiquidityPenaltyHook", abi.encode(offset), address(newHook));
 
         (PoolKey memory poolKey,) = initPool(currency0, currency1, IHooks(address(newHook)), fee, SQRT_PRICE_1_1);
 
@@ -423,9 +424,7 @@ contract LiquidityPenaltyHookTest is HookTest, BalanceDeltaAssertions {
             ) // 2**96 is an offset to avoid collision with the hook address already in the test
         );
 
-        deployCodeTo(
-            "src/general/LiquidityPenaltyHook.sol:LiquidityPenaltyHook", abi.encode(manager, offset), address(newHook)
-        );
+        deployCodeTo("src/general/LiquidityPenaltyHook.sol:LiquidityPenaltyHook", abi.encode(offset), address(newHook));
 
         (PoolKey memory poolKey,) = initPool(currency0, currency1, IHooks(address(newHook)), fee, SQRT_PRICE_1_1);
 

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -50,7 +50,7 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         );
         deployCodeTo(
             "src/mocks/ReHypothecationERC4626Mock.sol:ReHypothecationERC4626Mock",
-            abi.encode(manager, address(yieldSource0), address(yieldSource1)),
+            abi.encode(address(yieldSource0), address(yieldSource1)),
             address(hook)
         );
 
@@ -130,7 +130,7 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         );
         deployCodeTo(
             "src/mocks/ReHypothecationERC4626Mock.sol:ReHypothecationERC4626Mock",
-            abi.encode(manager, address(yieldSource0), address(yieldSource1)),
+            abi.encode(address(yieldSource0), address(yieldSource1)),
             address(newHook)
         );
         vm.expectRevert(ReHypothecationHook.NotInitialized.selector);
@@ -262,7 +262,7 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         );
         deployCodeTo(
             "src/mocks/ReHypothecationERC4626Mock.sol:ReHypothecationERC4626Mock",
-            abi.encode(manager, address(yieldSource0), address(yieldSource1)),
+            abi.encode(address(yieldSource0), address(yieldSource1)),
             address(newHook)
         );
         vm.expectRevert(ReHypothecationHook.NotInitialized.selector);

--- a/test/general/ReHypothecationHookNative.t.sol
+++ b/test/general/ReHypothecationHookNative.t.sol
@@ -48,7 +48,7 @@ contract ReHypothecationHookNativeTest is HookTest, BalanceDeltaAssertions {
         );
         deployCodeTo(
             "src/mocks/ReHypothecationNativeMock.sol:ReHypothecationNativeMock",
-            abi.encode(manager, address(yieldSource0), address(yieldSource1)),
+            abi.encode(address(yieldSource0), address(yieldSource1)),
             address(hook)
         );
 
@@ -107,7 +107,7 @@ contract ReHypothecationHookNativeTest is HookTest, BalanceDeltaAssertions {
         );
         deployCodeTo(
             "src/mocks/ReHypothecationNativeMock.sol:ReHypothecationNativeMock",
-            abi.encode(manager, address(yieldSource0), address(yieldSource1)),
+            abi.encode(address(yieldSource0), address(yieldSource1)),
             address(newHook)
         );
         (PoolKey memory nativeKey,) =

--- a/test/oracles/panoptic/Oracle.t.sol
+++ b/test/oracles/panoptic/Oracle.t.sol
@@ -9,7 +9,6 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
-import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
 import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
@@ -19,8 +18,9 @@ import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 import {OracleHookWithV3Adapters} from "../../../src/oracles/panoptic/OracleHookWithV3Adapters.sol";
 import {V3OracleAdapter} from "../../../src/oracles/panoptic/adapters/V3OracleAdapter.sol";
 import {V3TruncatedOracleAdapter} from "../../../src/oracles/panoptic/adapters/V3TruncatedOracleAdapter.sol";
+import {HookTest} from "test/utils/HookTest.sol";
 
-contract OracleTestV4 is Test, Deployers {
+contract OracleTestV4 is HookTest {
     using StateLibrary for IPoolManager;
 
     OracleHookWithV3Adapters public constant ORACLE_BASE =
@@ -256,7 +256,7 @@ contract OracleLibTest is Test {
         oracle = new OracleTestV4();
         manager = oracle.getManager();
 
-        deployCodeTo("OracleHookWithV3Adapters.sol", abi.encode(manager, int24(9116)), address(ORACLE_BASE));
+        deployCodeTo("OracleHookWithV3Adapters.sol", abi.encode(int24(9116)), address(ORACLE_BASE));
     }
 
     function test_fail_increaseObservationCardinalityNext_notInitialized() public {

--- a/test/utils/HookTest.sol
+++ b/test/utils/HookTest.sol
@@ -18,6 +18,13 @@ import {IPoolManagerEvents} from "test/utils/interfaces/IPoolManagerEvents.sol";
 
 // @dev Set of utilities to test Hooks.
 contract HookTest is Test, Deployers, IPoolManagerEvents, IHookEvents {
+    IPoolManager constant POOL_MANAGER = IPoolManager(address(0x000000000004444c5dc75cB358380D2e3dE08A90));
+
+    function deployFreshManager() internal override {
+        deployCodeTo("PoolManager", abi.encode(address(this)), address(POOL_MANAGER));
+        manager = POOL_MANAGER;
+    }
+
     // @dev Calculate the current `feesAccrued` for a given position.
     function calculateFees(
         IPoolManager manager,


### PR DESCRIPTION
Removes the `poolManager` constructor parameter and adds it instead as a poolManager() virtual function in the `BaseHook`, which uses the `0x000000000004444c5dc75cB358380D2e3dE08A90` Pool Manager Singleton by default, simplifying hooks construction. 