### PR TITLE
Extend LimitOrderHook to support native currency

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup
 
-      - uses: crytic/slither-action@v0.4.1
+      - uses: crytic/slither-action@v0.4.2
 
   codespell:
     name: CodeSpell

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/uniswap-hooks",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/uniswap-hooks",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@openzeppelin/contracts": "^5.5.0",
@@ -19,7 +19,7 @@
         "hardhat": "^2.26.3",
         "husky": "^9.1.7",
         "lint-staged": "^16.1.2",
-        "solhint": "^6.0.1",
+        "solhint": "^6.0.3",
         "solhint-plugin-openzeppelin": "file:scripts/solhint-custom",
         "solidity-docgen": "^0.6.0-beta.36"
       }
@@ -1240,16 +1240,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/antlr4": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.2.tgz",
-      "integrity": "sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/anymatch": {
@@ -4289,16 +4279,15 @@
       }
     },
     "node_modules/solhint": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/solhint/-/solhint-6.0.1.tgz",
-      "integrity": "sha512-Lew5nhmkXqHPybzBzkMzvvWkpOJSSLTkfTZwRriWvfR2naS4YW2PsjVGaoX9tZFmHh7SuS+e2GEGo5FPYYmJ8g==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/solhint/-/solhint-6.0.3.tgz",
+      "integrity": "sha512-LYiy1bN8X9eUsti13mbS4fY6ILVxhP6VoOgqbHxCsHl5VPnxOWf7U1V9ZvgizxdInKBMW82D1FNJO+daAcWHbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solidity-parser/parser": "^0.20.2",
         "ajv": "^6.12.6",
         "ajv-errors": "^1.0.1",
-        "antlr4": "^4.13.1-patch-1",
         "ast-parents": "^0.0.1",
         "better-ajv-errors": "^2.0.2",
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "hardhat": "^2.26.3",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
-    "solhint": "^6.0.1",
+    "solhint": "^6.0.3",
     "solhint-plugin-openzeppelin": "file:scripts/solhint-custom",
     "solidity-docgen": "^0.6.0-beta.36"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/uniswap-hooks",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Solidity library for secure and modular Uniswap hooks.",
   "files": [
     "/src/**/*.sol",

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -78,6 +78,7 @@ library OrderIdLibrary {
  *
  * _Available since v1.1.0_
  */
+// slither-disable-next-line locked-ether
 abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     using StateLibrary for IPoolManager;
     using OrderIdLibrary for OrderIdLibrary.OrderId;
@@ -134,9 +135,9 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     /// @dev Struct of callback data for the cancel callback.
     struct CancelCallbackData {
         PoolKey key;
-        int24 tickLower;
         int256 liquidityDelta;
         address to;
+        int24 tickLower;
         bool removingAllLiquidity;
         uint256 accumulatedFees0;
         uint256 accumulatedFees1;
@@ -375,9 +376,9 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
                         abi.encode(
                             CancelCallbackData(
                                 key,
-                                tickLower,
                                 -liquidity.toInt256(),
                                 to,
+                                tickLower,
                                 removingAllLiquidity,
                                 orderInfo.currency0Total,
                                 orderInfo.currency1Total
@@ -390,6 +391,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         );
 
         if (removingAllLiquidity) {
+            // slither-disable-next-line reentrancy-no-eth
             _setOrderId(key, tickLower, zeroForOne, ORDER_ID_DEFAULT);
             orderInfo.currency0Total = 0;
             orderInfo.currency1Total = 0;

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -424,9 +424,9 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
         if (liquidity == 0) revert ZeroLiquidity();
 
-        delete orderInfo.liquidity[msg.sender];
-
         uint128 liquidityTotal = orderInfo.liquidityTotal;
+        uint256 currency0Total = orderInfo.currency0Total;
+        uint256 currency1Total = orderInfo.currency1Total;
 
         uint256 checkpointCurrency0Fees = orderInfo.accruedFeesCheckpoints[msg.sender].currency0Fees;
         uint256 checkpointCurrency1Fees = orderInfo.accruedFeesCheckpoints[msg.sender].currency1Fees;
@@ -435,13 +435,14 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         // while `checkpoints` contains fees accrued at placement time.
         // Therefore, (fills + all fees) - (pre-checkpoint fees) = fills + post-checkpoint fees, which is exactly what
         // the withdrawer is entitled to.
-        amount0 = FullMath.mulDiv(orderInfo.currency0Total - checkpointCurrency0Fees, liquidity, liquidityTotal);
-        amount1 = FullMath.mulDiv(orderInfo.currency1Total - checkpointCurrency1Fees, liquidity, liquidityTotal);
+        amount0 = FullMath.mulDiv(currency0Total - checkpointCurrency0Fees, liquidity, liquidityTotal);
+        amount1 = FullMath.mulDiv(currency1Total - checkpointCurrency1Fees, liquidity, liquidityTotal);
 
-        orderInfo.currency0Total -= amount0;
-        orderInfo.currency1Total -= amount1;
+        delete orderInfo.liquidity[msg.sender];
+        orderInfo.liquidityTotal = liquidityTotal - liquidity;
 
-        orderInfo.liquidityTotal -= liquidity;
+        orderInfo.currency0Total = currency0Total - amount0;
+        orderInfo.currency1Total = currency1Total - amount1;
 
         // Unlock the poolManager, which will call back this contract `unlockCallback`.
         poolManager.unlock(

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -4,6 +4,7 @@
 pragma solidity ^0.8.26;
 
 // External imports
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {FullMath} from "@uniswap/v4-core/src/libraries/FullMath.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
@@ -22,13 +23,13 @@ import {BaseHook} from "../base/BaseHook.sol";
 /**
  * @dev The OrderId library.
  *
- * The LimitOrderHook uses OrderIds to track distinct lifecycle instances of orders at the same pool location.
+ * The LimitOrderHook uses OrderIds to track distinct lifecycle instances of orders at the same pool locations.
  *
- * Orders are identified by an OrderKey computed as keccak256(poolKey, tickLower, zeroForOne). Multiple users
- * can add liquidity to the same OrderKey, sharing a single position. When an order is filled or fully cancelled,
- * the position is removed and users withdraw their liquidity.
+ * Orders are identified by an OrderKey computed as a hash of its parameters. Multiple users can add liquidity
+ * to the same OrderKey, sharing a single position owned by the hook. When an order is filled or completely
+ * cancelled, the position is removed and users withdraw their liquidity.
  *
- * If users later place a new order at the same tick and direction, the OrderKey remains identical but must map
+ * If users later place a new order at the same tick and direction, the OrderKey remains identical but maps
  * to a new OrderId. This ensures accounting state (currency totals, liquidity mappings, filled status) remains
  * independent between the original and subsequent orders.
  *
@@ -72,12 +73,16 @@ library OrderIdLibrary {
  * not give any warranties and will not be liable for any losses incurred through any use of this code
  * base.
  *
+ * Note: since the PoolManager implements a ReentrancyGuard, {placeOrder, cancelOrder, withdraw} are already
+ * protected from reentrancy.
+ *
  * _Available since v1.1.0_
  */
 abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     using StateLibrary for IPoolManager;
     using OrderIdLibrary for OrderIdLibrary.OrderId;
     using CurrencySettler for Currency;
+    using SafeCast for *;
 
     /// @dev The info for orders identified by OrderId.
     struct OrderInfo {
@@ -95,7 +100,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         bool filled;
         /// @dev The liquidity of the order owned by each placer.
         mapping(address owner => uint128 amount) liquidity;
-        /// @dev The checkpoints for the order, used to protect from stealing accrued fees.
+        /// @dev Checkpoints of the `currency0Total` and `currency1Total` the last time the owner added liquidity
+        /// to the order, used as enhanced accounting to protect from accrued fees being stolen.
         mapping(address owner => CheckpointCurrencies checkpoint) checkpoints;
     }
 
@@ -119,6 +125,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         bool zeroForOne;
         int24 tickLower;
         uint128 liquidity;
+        uint256 value;
     }
 
     /// @dev Struct of callback data for the cancel callback.
@@ -128,6 +135,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         int256 liquidityDelta;
         address to;
         bool removingAllLiquidity;
+        uint256 accumulatedFees0;
+        uint256 accumulatedFees1;
     }
 
     /// @dev Struct of callback data for the withdraw callback
@@ -160,20 +169,19 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     /// @dev The last tick lower for each pool.
     mapping(PoolId poolId => int24 tickLowerLast) private _tickLowerLasts;
 
-    /// @dev Tracks the order id for a given `orderKey` current lifecycle instance.
+    /// @dev Tracks the `orderId` for a given `orderKey` current lifecycle instance.
     mapping(bytes32 orderKey => OrderIdLibrary.OrderId orderId) private _orderIds;
 
-    /// @dev Tracks the order info for each order id.
+    /// @dev Tracks the `OrderInfo` for each `orderId`.
+    // slither-disable-next-line uninitialized-state
     mapping(OrderIdLibrary.OrderId orderId => OrderInfo orderInfo) private _orderInfos;
 
     /// @dev Zero liquidity was attempted to be added or removed.
     error ZeroLiquidity();
 
-    /// @dev Limit order was placed in range.
-    error InRange();
-
-    /// @dev Limit order placed on the wrong side of the range.
-    error CrossedRange();
+    /// @dev Limit order was placed in an invalid range.
+    /// Note: limit orders can only be placed out of the current range as single side liquidity.
+    error InvalidRange();
 
     /// @dev Limit order was already filled.
     error Filled();
@@ -183,6 +191,15 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
     /// @dev An unsupported callback type was received.
     error UnsupportedCallback();
+
+    /// @dev Native currency was sent for a non-native order.
+    error InvalidValue();
+
+    /// @dev Not enough native currency was sent.
+    error InsufficientValue();
+
+    /// @dev The native currency refund failed.
+    error RefundFailed();
 
     /**
      * @dev Emitted when an `owner` places a limit order with the given `orderId`, in the pool identified by `key`,
@@ -236,7 +253,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         return this.afterInitialize.selector;
     }
 
-    /// @dev Hooks into the `afterSwap` hook to get the ticks crossed by the swap and fill the orders that are crossed, filling them.
+    /// @dev Hooks into the `afterSwap` hook to get the ticks crossed by the swap and filling the crossed limit orders.
     function _afterSwap(address, PoolKey calldata key, SwapParams calldata params, BalanceDelta, bytes calldata)
         internal
         virtual
@@ -268,24 +285,29 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     function placeOrder(PoolKey calldata key, int24 tick, bool zeroForOne, uint128 liquidity) public payable virtual {
         if (liquidity == 0) revert ZeroLiquidity();
 
-        OrderInfo storage orderInfo;
+        // the `msg.value` should be positive if the order is a native placement, and 0 otherwise
+        if (key.currency0.isAddressZero() && zeroForOne) {
+            if (msg.value == 0) revert InsufficientValue();
+        } else if (msg.value != 0) {
+            revert InvalidValue();
+        }
 
         // get the OrderKey and it's associated OrderId
         bytes32 orderKey = getOrderKey(key, tick, zeroForOne);
         OrderIdLibrary.OrderId orderId = getOrderId(orderKey);
 
+        OrderInfo storage orderInfo;
+
         // if the order is not initialized, initialize it
         if (orderId.equals(ORDER_ID_DEFAULT)) {
-            // initialize the order to the next order
             unchecked {
                 _setOrderId(orderKey, orderId = _orderIdNext);
                 _orderIdNext = _orderIdNext.unsafeIncrement();
             }
 
-            // get the order info
             orderInfo = _orderInfos[orderId];
 
-            // set the currency0 and currency1
+            // set the order currencies
             orderInfo.currency0 = key.currency0;
             orderInfo.currency1 = key.currency1;
         } else {
@@ -299,13 +321,11 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             orderInfo.liquidity[msg.sender] += liquidity;
         }
 
-        // @TBD: I don't think the phrase below "Note that the amounts in the checkpoints can only be from fees accrued,
-        // never from order fills." is correct.
-
         // set the currency checkpoints for the msg.sender. These amounts are stored so that the user cannot steal
         // fees accrued before the checkpoint. Note that the amounts in the checkpoints can only be from fees accrued,
-        // never from order fills. The checkpoint is updated every time the user places an order.
-        // This means possible fees accrued in between checkpoints are not taken into account, so the user is not entitled to them.
+        // never from order fills, since thes checkpoint are updated only when the user places an order, and placing
+        // is only possible while the order is unfilled. This means possible fees accrued in between checkpoints are
+        // not taken into account, so the user is not entitled to them.
         orderInfo.checkpoints[msg.sender].amountCurrency0 = orderInfo.currency0Total;
         orderInfo.checkpoints[msg.sender].amountCurrency1 = orderInfo.currency1Total;
 
@@ -318,14 +338,15 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             poolManager.unlock(
                 abi.encode(
                     CallbackData(
-                        CallbackType.Place, abi.encode(PlaceCallbackData(key, msg.sender, zeroForOne, tick, liquidity))
+                        CallbackType.Place,
+                        abi.encode(PlaceCallbackData(key, msg.sender, zeroForOne, tick, liquidity, msg.value))
                     )
                 )
             ),
             (uint256, uint256)
         );
 
-        // add the fees to the order info
+        // add any accrued fees to the order info
         // note that the currency totals must be updated after poolManager call as they depend on the returned values of the callback.
         // This is safe as these functions are only callable on the trusted poolManager
         unchecked {
@@ -347,9 +368,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      * The interaction with the `poolManager` is done via the `unlock` function, which will trigger the `{unlockCallback}` function.
      */
     function cancelOrder(PoolKey calldata key, int24 tickLower, bool zeroForOne, address to) public virtual {
-        // get the order
-        bytes32 orderKey = getOrderKey(key, tickLower, zeroForOne);
-        OrderIdLibrary.OrderId orderId = getOrderId(orderKey);
+        // get the OrderId and it's associated OrderInfo
+        OrderIdLibrary.OrderId orderId = getOrderId(key, tickLower, zeroForOne);
         OrderInfo storage orderInfo = _orderInfos[orderId];
 
         // revert if the order is already filled
@@ -365,15 +385,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         delete orderInfo.liquidity[msg.sender];
 
         bool removingAllLiquidity = liquidity == orderInfo.liquidityTotal;
-
         // subtract the liquidity from the total liquidity
         orderInfo.liquidityTotal -= liquidity;
-
-        if (removingAllLiquidity) {
-            _setOrderId(orderKey, ORDER_ID_DEFAULT);
-            orderInfo.currency0Total = 0;
-            orderInfo.currency1Total = 0;
-        }
 
         // unlock the callback to the poolManager, the callback will trigger `unlockCallback`
         // and remove the liquidity from the pool. Note that this function will return the fees accrued
@@ -386,7 +399,15 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
                     CallbackData(
                         CallbackType.Cancel,
                         abi.encode(
-                            CancelCallbackData(key, tickLower, -int256(uint256(liquidity)), to, removingAllLiquidity)
+                            CancelCallbackData(
+                                key,
+                                tickLower,
+                                -liquidity.toInt256(),
+                                to,
+                                removingAllLiquidity,
+                                orderInfo.currency0Total,
+                                orderInfo.currency1Total
+                            )
                         )
                     )
                 )
@@ -394,14 +415,20 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             (uint256, uint256)
         );
 
-        // add the fees to the order info
-        // note that the currency totals must be updated after poolManager call as they depend on the returned values of the callback.
-        // This is safe as these functions are only callable on the trusted poolManager
-        unchecked {
-            // slither-disable-next-line reentrancy-no-eth
-            orderInfo.currency0Total += amount0Fee;
-            // slither-disable-next-line reentrancy-no-eth
-            orderInfo.currency1Total += amount1Fee;
+        if (removingAllLiquidity) {
+            _setOrderId(key, tickLower, zeroForOne, ORDER_ID_DEFAULT);
+            orderInfo.currency0Total = 0;
+            orderInfo.currency1Total = 0;
+        } else {
+            // add the fees to the order info
+            // note that the currency totals must be updated after poolManager call as they depend on the returned values of the callback.
+            // This is safe as these functions are only callable on the trusted poolManager
+            unchecked {
+                // slither-disable-next-line reentrancy-no-eth
+                orderInfo.currency0Total += amount0Fee;
+                // slither-disable-next-line reentrancy-no-eth
+                orderInfo.currency1Total += amount1Fee;
+            }
         }
 
         // emit the cancel event
@@ -428,10 +455,10 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         // get the liquidity added by the msg.sender
         uint128 liquidity = orderInfo.liquidity[msg.sender];
 
-        // revert if the liquidity is 0
+        // revert if the sender liquidity is 0
         if (liquidity == 0) revert ZeroLiquidity();
 
-        // delete the liquidity from the order
+        // delete the sender liquidity from the order
         delete orderInfo.liquidity[msg.sender];
 
         // get the total liquidity in the order
@@ -442,6 +469,9 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
         // calculate the amount of currency0 and currency1 owed to the msg.sender
         // note that the user is not able to withdraw funds that were accrued before their checkpoint.
+        // `currencyTotals` at this point are the fill amounts + any accrued fees,
+        // while `checkpoints` are the fees accrued before the withdrawer placed his order.
+        // therefore, `orderInfo.currency0Total - checkpointAmountCurrency0` gives us the exact amount owed to the withdrawer.
         amount0 = FullMath.mulDiv(orderInfo.currency0Total - checkpointAmountCurrency0, liquidity, liquidityTotal);
         amount1 = FullMath.mulDiv(orderInfo.currency1Total - checkpointAmountCurrency1, liquidity, liquidityTotal);
 
@@ -506,46 +536,53 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         virtual
         returns (uint256 amount0Fee, uint256 amount1Fee)
     {
-        PoolKey memory key = placeData.key;
-
         // add the out of range liquidity to the pool
         (BalanceDelta callerDelta, BalanceDelta feesAccrued) = poolManager.modifyLiquidity(
-            key,
+            placeData.key,
             ModifyLiquidityParams({
                 tickLower: placeData.tickLower,
-                tickUpper: placeData.tickLower + key.tickSpacing,
+                tickUpper: placeData.tickLower + placeData.key.tickSpacing,
                 liquidityDelta: int256(uint256(placeData.liquidity)),
                 salt: 0
             }),
             ZERO_BYTES
         );
 
+        // collect the fees from the pool to the hook
         if (feesAccrued.amount0() > 0) {
-            key.currency0.take(poolManager, address(this), amount0Fee = uint256(uint128(feesAccrued.amount0())), true);
+            placeData.key.currency0
+                .take(poolManager, address(this), amount0Fee = feesAccrued.amount0().toUint256(), true);
         }
         if (feesAccrued.amount1() > 0) {
-            key.currency1.take(poolManager, address(this), amount1Fee = uint256(uint128(feesAccrued.amount1())), true);
+            placeData.key.currency1
+                .take(poolManager, address(this), amount1Fee = feesAccrued.amount1().toUint256(), true);
         }
 
         BalanceDelta principalDelta = callerDelta - feesAccrued;
 
-        // if the amount of currency0 is negative, the limit order is to sell `currency0` for `currency1`
-        if (principalDelta.amount0() < 0) {
-            // if the amount of currency1 is not 0, the limit order is in range
-            if (principalDelta.amount1() != 0) revert InRange();
-            // if `zeroForOne` is false, the limit order is wrong side of the range
-            if (!placeData.zeroForOne) revert CrossedRange();
+        // order swaps currency0 to currency1, therefore should only add currency0.
+        if (placeData.zeroForOne) {
+            // if the order is not adding currency0, or currency1 is involved, the order is invalid
+            if (principalDelta.amount0() >= 0 || principalDelta.amount1() != 0) revert InvalidRange();
 
-            // settle the currency0 to the owner
-            key.currency0.settle(poolManager, placeData.owner, uint256(uint128(-principalDelta.amount0())), false);
+            // if the currency0 is native, refund any excess in the msg value
+            // Note that the poolManager is already protected from reentrancy via a reentrancy guard.
+            if (placeData.key.currency0.isAddressZero()) {
+                int256 refundAmount = int256(placeData.value) - -(principalDelta.amount0());
+                if (refundAmount < 0) revert InsufficientValue();
+                if (refundAmount > 0) {
+                    (bool success,) = placeData.owner.call{value: refundAmount.toUint256()}("");
+                    if (!success) revert RefundFailed();
+                }
+            }
+
+            // settle the currency0 from the sender to the pool
+            placeData.key.currency0.settle(poolManager, placeData.owner, (-principalDelta.amount0()).toUint256(), false);
         } else {
-            // if the amount of currency0 is not 0, the limit order is in range
-            if (principalDelta.amount0() != 0) revert InRange();
-            // if `zeroForOne` is true, the limit order is wrong side of the range
-            if (placeData.zeroForOne) revert CrossedRange();
-
-            // settle the currency1 to the owner
-            key.currency1.settle(poolManager, placeData.owner, uint256(uint128(-principalDelta.amount1())), false);
+            // if the order is not adding currency1, or currency0 is involved, the order is invalid
+            if (principalDelta.amount1() >= 0 || principalDelta.amount0() != 0) revert InvalidRange();
+            // settle the currency1 from the sender to the pool
+            placeData.key.currency1.settle(poolManager, placeData.owner, (-principalDelta.amount1()).toUint256(), false);
         }
     }
 
@@ -559,14 +596,12 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         virtual
         returns (uint256 amount0Fee, uint256 amount1Fee)
     {
-        int24 tickUpper = cancelData.tickLower + cancelData.key.tickSpacing;
-
-        // remove the liquidity from the pool. The fees accrued by the position are included in the `cancelDelta`
-        (BalanceDelta cancelDelta, BalanceDelta feesAccrued) = poolManager.modifyLiquidity(
+        // remove the liquidity from the pool. The fees accrued by the position are included in the `callerDelta`
+        (BalanceDelta callerDelta, BalanceDelta feesAccrued) = poolManager.modifyLiquidity(
             cancelData.key,
             ModifyLiquidityParams({
                 tickLower: cancelData.tickLower,
-                tickUpper: tickUpper,
+                tickUpper: cancelData.tickLower + cancelData.key.tickSpacing,
                 liquidityDelta: cancelData.liquidityDelta,
                 salt: 0
             }),
@@ -580,37 +615,45 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         // could be unfairly diluted by a user synchronously placing then canceling a limit order to skim off fees.
         // to prevent this, we allocate all fee revenue to remaining limit order placers, unless this is the last order.
         if (!cancelData.removingAllLiquidity) {
+            // if the `removingAllLiquidity` flag is false, the fees accrued will be allocated to the remaining limit order placers
+            // so we need to subtract the fees from the `cancelDelta` to get the principal delta
+            principalDelta = callerDelta - feesAccrued;
+
             // if the amount of fees in currency0 is positive, mint currency0 to the hook
             if (feesAccrued.amount0() > 0) {
                 poolManager.mint(
-                    address(this), cancelData.key.currency0.toId(), amount0Fee = uint128(feesAccrued.amount0())
+                    address(this), cancelData.key.currency0.toId(), amount0Fee = feesAccrued.amount0().toUint256()
                 );
             }
 
             // if the amount of fees in currency1 is positive, mint currency1 to the hook
             if (feesAccrued.amount1() > 0) {
                 poolManager.mint(
-                    address(this), cancelData.key.currency1.toId(), amount1Fee = uint128(feesAccrued.amount1())
+                    address(this), cancelData.key.currency1.toId(), amount1Fee = feesAccrued.amount1().toUint256()
                 );
             }
-
-            // if the `removingAllLiquidity` flag is false, the fees accrued will be allocated to the remaining limit order placers
-            // so we need to subtract the fees from the `cancelDelta` to get the principal delta
-            principalDelta = cancelDelta - feesAccrued;
         } else {
             // if the `removingAllLiquidity` flag is true, the fees accrued will be allocated to the placer of the last limit order being cancelled
-            // so we can just use the `cancelDelta` as the principal delta
-            principalDelta = cancelDelta;
+            // so we can just use the `cancelDelta` as the principal delta (includes fees from this modifyLiquidity)
+            principalDelta = callerDelta;
+
+            // also transfer previously accumulated fees (minted to hook by earlier cancellers)
+            if (cancelData.accumulatedFees0 > 0) {
+                poolManager.burn(address(this), cancelData.key.currency0.toId(), cancelData.accumulatedFees0);
+                poolManager.take(cancelData.key.currency0, cancelData.to, cancelData.accumulatedFees0);
+            }
+            if (cancelData.accumulatedFees1 > 0) {
+                poolManager.burn(address(this), cancelData.key.currency1.toId(), cancelData.accumulatedFees1);
+                poolManager.take(cancelData.key.currency1, cancelData.to, cancelData.accumulatedFees1);
+            }
         }
 
-        // if the amount of currency0 is positive, take the currency0 from the pool and send it to the `to` address
+        // transfer principal to the caller (for both cases)
         if (principalDelta.amount0() > 0) {
-            cancelData.key.currency0.take(poolManager, cancelData.to, uint256(uint128(principalDelta.amount0())), false);
+            cancelData.key.currency0.take(poolManager, cancelData.to, principalDelta.amount0().toUint256(), false);
         }
-
-        // if the amount of currency1 is positive, take the currency1 from the pool and send it to the `to` address
         if (principalDelta.amount1() > 0) {
-            cancelData.key.currency1.take(poolManager, cancelData.to, uint256(uint128(principalDelta.amount1())), false);
+            cancelData.key.currency1.take(poolManager, cancelData.to, principalDelta.amount1().toUint256(), false);
         }
     }
 
@@ -663,25 +706,20 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
                 ModifyLiquidityParams({
                     tickLower: tickLower,
                     tickUpper: tickLower + key.tickSpacing,
-                    liquidityDelta: -int256(uint256(orderInfo.liquidityTotal)),
+                    liquidityDelta: -orderInfo.liquidityTotal.toInt256(),
                     salt: 0
                 }),
                 ZERO_BYTES
             );
 
-            // slither-disable-next-line uninitialized-local
-            uint128 amount0;
-            // slither-disable-next-line uninitialized-local
-            uint128 amount1;
-
             // if the amount of currency0 is positive, mint the currency0 to the hook
             if (delta.amount0() > 0) {
-                poolManager.mint(address(this), key.currency0.toId(), amount0 = uint128(delta.amount0()));
+                poolManager.mint(address(this), key.currency0.toId(), delta.amount0().toUint256());
             }
 
             // if the amount of currency1 is positive, mint the currency1 to the hook
             if (delta.amount1() > 0) {
-                poolManager.mint(address(this), key.currency1.toId(), amount1 = uint128(delta.amount1()));
+                poolManager.mint(address(this), key.currency1.toId(), delta.amount1().toUint256());
             }
 
             // add the amount of currency0 and currency1 to the order info
@@ -689,12 +727,11 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             // This is safe as these functions are only callable on the trusted poolManager
             unchecked {
                 // slither-disable-next-line reentrancy-no-eth
-                orderInfo.currency0Total += amount0;
+                orderInfo.currency0Total += delta.amount0().toUint256();
                 // slither-disable-next-line reentrancy-no-eth
-                orderInfo.currency1Total += amount1;
+                orderInfo.currency1Total += delta.amount1().toUint256();
             }
 
-            // emit the fill event
             emit Fill(orderId, key, tickLower, zeroForOne);
             // slither-disable-end calls-loop
         }
@@ -710,7 +747,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         view
         returns (int24 tickLower, int24 lower, int24 upper)
     {
-        tickLower = _getTickLower(_getTick(poolId), tickSpacing);
+        tickLower = _getTickLower(_getCurrentTick(poolId), tickSpacing);
         int24 tickLowerLast = getTickLowerLast(poolId);
 
         if (tickLower < tickLowerLast) {
@@ -731,18 +768,22 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     }
 
     /**
-     * @dev Retrieves the order key for a given pool position. Takes a `PoolKey` `key`, target `tickLower`, and direction
-     * `zeroForOne` indicating whether it's buying currency0 or currency1. Returns the {bytes32} associated with this
-     * position.
+     * @dev Retrieves the `orderKey` for a given pool position parameters. Takes a `PoolKey` `key`, target `tickLower`, and direction
+     * `zeroForOne` indicating whether it's buying currency0 or currency1.
      */
     function getOrderKey(PoolKey memory key, int24 tickLower, bool zeroForOne) public pure returns (bytes32) {
         return keccak256(abi.encode(key, tickLower, zeroForOne));
     }
 
     /**
-     * @dev Retrieves the order id for a given pool position. Takes a `PoolKey` `key`, target `tickLower`, and direction
-     * `zeroForOne` indicating whether it's buying currency0 or currency1. Returns the {OrderId} associated with this
-     * position, or the default order id if no order exists.
+     * @dev Retrieves the current `orderKey` lifecycle `orderId` or the default `orderId` if the order is not initialized.
+     */
+    function getOrderId(bytes32 orderKey) public view returns (OrderIdLibrary.OrderId) {
+        return _orderIds[orderKey];
+    }
+
+    /**
+     * @dev Overload that retrieves the `orderId` for a given order parameters.
      */
     function getOrderId(PoolKey memory key, int24 tickLower, bool zeroForOne)
         public
@@ -753,18 +794,19 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     }
 
     /**
-     * @dev Overload that retrieves the order id for a given order key.
+     * @dev Updates the current `orderKey` lifecycle `orderId`.
      */
-    function getOrderId(bytes32 orderKey) public view returns (OrderIdLibrary.OrderId) {
-        return _orderIds[orderKey];
+    function _setOrderId(bytes32 orderKey, OrderIdLibrary.OrderId orderId) internal {
+        _orderIds[orderKey] = orderId;
     }
 
     /**
-     * @dev Internal helper that updates the order ID mapping. Takes a `PoolKey` `key`, target `tickLower`, direction
-     * `zeroForOne`, and `orderId` to store. Associates the given order id with the pool position's hash.
+     * @dev Overload that retrieves the `orderKey` for a given order parameters.
      */
-    function _setOrderId(bytes32 orderKey, OrderIdLibrary.OrderId orderId) private {
-        _orderIds[orderKey] = orderId;
+    function _setOrderId(PoolKey memory key, int24 tickLower, bool zeroForOne, OrderIdLibrary.OrderId orderId)
+        internal
+    {
+        _setOrderId(getOrderKey(key, tickLower, zeroForOne), orderId);
     }
 
     /**
@@ -779,24 +821,22 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     }
 
     /**
-     * @dev Get the liquidity of an order for a given order id and owner. Takes an {OrderId} `orderId` and `owner` address
-     * and returns the amount of liquidity the owner has contributed to the order.
+     * @dev Retrieves the liquidity of a given `orderId` owned by a given `owner`.
      */
     function getOrderLiquidity(OrderIdLibrary.OrderId orderId, address owner) external view returns (uint256) {
         return _orderInfos[orderId].liquidity[owner];
     }
 
     /**
-     * @dev Get the current tick for a given pool. Takes a `PoolId` `poolId` and returns the tick calculated
-     * from the pool's current sqrt price.
+     * @dev Retrieves the current tick of a given `poolId`.
      */
-    function _getTick(PoolId poolId) internal view returns (int24 tick) {
+    function _getCurrentTick(PoolId poolId) internal view returns (int24 tick) {
         (uint160 sqrtPriceX96,,,) = poolManager.getSlot0(poolId);
         tick = TickMath.getTickAtSqrtPrice(sqrtPriceX96);
     }
 
     /**
-     * @dev Get the order info for a given order id. Takes an {OrderId} `orderId` and returns the order info.
+     * @dev Retrieves the `OrderInfo` for a given `orderId`.
      */
     function getOrderInfo(OrderIdLibrary.OrderId orderId)
         external

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -19,15 +19,27 @@ import {SwapParams, ModifyLiquidityParams} from "@uniswap/v4-core/src/types/Pool
 import {CurrencySettler} from "../utils/CurrencySettler.sol";
 import {BaseHook} from "../base/BaseHook.sol";
 
-/// @dev The order id library.
+/**
+ * @dev The OrderId library.
+ *
+ * The LimitOrderHook uses OrderIds to track distinct lifecycle instances of orders at the same pool location.
+ *
+ * Orders are identified by an OrderKey computed as keccak256(poolKey, tickLower, zeroForOne). Multiple users
+ * can add liquidity to the same OrderKey, sharing a single position. When an order is filled or fully cancelled,
+ * the position is removed and users withdraw their liquidity.
+ *
+ * If users later place a new order at the same tick and direction, the OrderKey remains identical but must map
+ * to a new OrderId. This ensures accounting state (currency totals, liquidity mappings, filled status) remains
+ * independent between the original and subsequent orders.
+ *
+ * NOTE: OrderKey identifies location and direction, while OrderId identifies the unique lifecycle instance.
+ * An OrderKey may map to different OrderIds over time as orders are filled and recreated.
+ */
 library OrderIdLibrary {
     /// @dev The order id type.
     type OrderId is uint232;
 
-    /**
-     * @dev Compare two order ids for equality. Takes two `OrderId` values `a` and `b` and
-     * returns whether their underlying values are equal.
-     */
+    /// @dev Compare two order ids for equality.
     function equals(OrderId a, OrderId b) internal pure returns (bool) {
         return OrderId.unwrap(a) == OrderId.unwrap(b);
     }
@@ -67,15 +79,23 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     using OrderIdLibrary for OrderIdLibrary.OrderId;
     using CurrencySettler for Currency;
 
-    /// @dev The info for each order id.
+    /// @dev The info for orders identified by OrderId.
     struct OrderInfo {
+        /// @dev The currency0 of the order.
         Currency currency0;
+        /// @dev The currency1 of the order.
         Currency currency1;
+        /// @dev The total currency0 of the order including fees resting inactive in the hook.
         uint256 currency0Total;
+        /// @dev The total currency1 of the order including fees resting inactive in the hook.
         uint256 currency1Total;
+        /// @dev The total liquidity of the order provided by all the limit order placers.
         uint128 liquidityTotal;
+        /// @dev Whether the order is filled or not.
         bool filled;
+        /// @dev The liquidity of the order owned by each placer.
         mapping(address owner => uint128 amount) liquidity;
+        /// @dev The checkpoints for the order, used to protect from stealing accrued fees.
         mapping(address owner => CheckpointCurrencies checkpoint) checkpoints;
     }
 
@@ -140,7 +160,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     /// @dev The last tick lower for each pool.
     mapping(PoolId poolId => int24 tickLowerLast) private _tickLowerLasts;
 
-    /// @dev Tracks each order id for a given `orderKey`, defined by `keccak256` of the `poolKey`, `tickLower`, and `zeroForOne`.
+    /// @dev Tracks the order id for a given `orderKey` current lifecycle instance.
     mapping(bytes32 orderKey => OrderIdLibrary.OrderId orderId) private _orderIds;
 
     /// @dev Tracks the order info for each order id.
@@ -160,6 +180,9 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
     /// @dev Limit order is not filled.
     error NotFilled();
+
+    /// @dev An unsupported callback type was received.
+    error UnsupportedCallback();
 
     /**
      * @dev Emitted when an `owner` places a limit order with the given `orderId`, in the pool identified by `key`,
@@ -227,11 +250,10 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         // set the last tick lower for the pool
         _tickLowerLasts[key.toId()] = tickLower;
 
-        // note that a zeroForOne swap means that the pool is actually gaining token0, so limit
-        // order fills are the opposite of swap fills, hence the inversion below
-        bool zeroForOne = !params.zeroForOne;
         for (; lower <= upper; lower += key.tickSpacing) {
-            _fillOrder(key, lower, zeroForOne);
+            // note that a zeroForOne swap means that the pool is actually gaining token0, so limit
+            // order fills are the opposite of swap fills, hence the inversion below
+            _fillOrder(key, lower, !params.zeroForOne);
         }
 
         return (this.afterSwap.selector, 0);
@@ -243,21 +265,20 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      * whether to buy currency0 or currency1, and amount of `liquidity` to place. The interaction with the `poolManager` is done
      * via the `unlock` function, which will trigger the `{unlockCallback}` function.
      */
-    function placeOrder(PoolKey calldata key, int24 tick, bool zeroForOne, uint128 liquidity) public virtual {
+    function placeOrder(PoolKey calldata key, int24 tick, bool zeroForOne, uint128 liquidity) public payable virtual {
         if (liquidity == 0) revert ZeroLiquidity();
 
         OrderInfo storage orderInfo;
 
-        // get the order for the limit order
-        OrderIdLibrary.OrderId orderId = getOrderId(key, tick, zeroForOne);
+        // get the OrderKey and it's associated OrderId
+        bytes32 orderKey = getOrderKey(key, tick, zeroForOne);
+        OrderIdLibrary.OrderId orderId = getOrderId(orderKey);
 
         // if the order is not initialized, initialize it
         if (orderId.equals(ORDER_ID_DEFAULT)) {
             // initialize the order to the next order
             unchecked {
-                _setOrderId(key, tick, zeroForOne, orderId = _orderIdNext);
-
-                // increment the order id
+                _setOrderId(orderKey, orderId = _orderIdNext);
                 _orderIdNext = _orderIdNext.unsafeIncrement();
             }
 
@@ -277,6 +298,10 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             orderInfo.liquidityTotal += liquidity;
             orderInfo.liquidity[msg.sender] += liquidity;
         }
+
+        // @TBD: I don't think the phrase below "Note that the amounts in the checkpoints can only be from fees accrued,
+        // never from order fills." is correct.
+
         // set the currency checkpoints for the msg.sender. These amounts are stored so that the user cannot steal
         // fees accrued before the checkpoint. Note that the amounts in the checkpoints can only be from fees accrued,
         // never from order fills. The checkpoint is updated every time the user places an order.
@@ -323,7 +348,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      */
     function cancelOrder(PoolKey calldata key, int24 tickLower, bool zeroForOne, address to) public virtual {
         // get the order
-        OrderIdLibrary.OrderId orderId = getOrderId(key, tickLower, zeroForOne);
+        bytes32 orderKey = getOrderKey(key, tickLower, zeroForOne);
+        OrderIdLibrary.OrderId orderId = getOrderId(orderKey);
         OrderInfo storage orderInfo = _orderInfos[orderId];
 
         // revert if the order is already filled
@@ -339,11 +365,12 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         delete orderInfo.liquidity[msg.sender];
 
         bool removingAllLiquidity = liquidity == orderInfo.liquidityTotal;
+
         // subtract the liquidity from the total liquidity
         orderInfo.liquidityTotal -= liquidity;
 
         if (removingAllLiquidity) {
-            _setOrderId(key, tickLower, zeroForOne, ORDER_ID_DEFAULT);
+            _setOrderId(orderKey, ORDER_ID_DEFAULT);
             orderInfo.currency0Total = 0;
             orderInfo.currency1Total = 0;
         }
@@ -465,6 +492,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             _handleWithdrawCallback(withdrawData);
             return ZERO_BYTES;
         }
+
+        revert UnsupportedCallback();
     }
 
     /**
@@ -614,7 +643,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      */
     function _fillOrder(PoolKey calldata key, int24 tickLower, bool zeroForOne) internal virtual {
         // slither-disable-start calls-loop
-        OrderIdLibrary.OrderId orderId = getOrderId(key, tickLower, zeroForOne);
+        bytes32 orderKey = getOrderKey(key, tickLower, zeroForOne);
+        OrderIdLibrary.OrderId orderId = getOrderId(orderKey);
 
         // if the order is not default (not initialized), fill it
         if (!orderId.equals(ORDER_ID_DEFAULT)) {
@@ -625,7 +655,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             orderInfo.filled = true;
 
             // set the order as default (inactive)
-            _setOrderId(key, tickLower, zeroForOne, ORDER_ID_DEFAULT);
+            _setOrderId(orderKey, ORDER_ID_DEFAULT);
 
             // modify the liquidity to remove the order liquidity from the pool
             (BalanceDelta delta,) = poolManager.modifyLiquidity(
@@ -701,6 +731,15 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     }
 
     /**
+     * @dev Retrieves the order key for a given pool position. Takes a `PoolKey` `key`, target `tickLower`, and direction
+     * `zeroForOne` indicating whether it's buying currency0 or currency1. Returns the {bytes32} associated with this
+     * position.
+     */
+    function getOrderKey(PoolKey memory key, int24 tickLower, bool zeroForOne) public pure returns (bytes32) {
+        return keccak256(abi.encode(key, tickLower, zeroForOne));
+    }
+
+    /**
      * @dev Retrieves the order id for a given pool position. Takes a `PoolKey` `key`, target `tickLower`, and direction
      * `zeroForOne` indicating whether it's buying currency0 or currency1. Returns the {OrderId} associated with this
      * position, or the default order id if no order exists.
@@ -710,15 +749,22 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         view
         returns (OrderIdLibrary.OrderId)
     {
-        return _orderIds[keccak256(abi.encode(key, tickLower, zeroForOne))];
+        return getOrderId(getOrderKey(key, tickLower, zeroForOne));
+    }
+
+    /**
+     * @dev Overload that retrieves the order id for a given order key.
+     */
+    function getOrderId(bytes32 orderKey) public view returns (OrderIdLibrary.OrderId) {
+        return _orderIds[orderKey];
     }
 
     /**
      * @dev Internal helper that updates the order ID mapping. Takes a `PoolKey` `key`, target `tickLower`, direction
      * `zeroForOne`, and `orderId` to store. Associates the given order id with the pool position's hash.
      */
-    function _setOrderId(PoolKey memory key, int24 tickLower, bool zeroForOne, OrderIdLibrary.OrderId orderId) private {
-        _orderIds[keccak256(abi.encode(key, tickLower, zeroForOne))] = orderId;
+    function _setOrderId(bytes32 orderKey, OrderIdLibrary.OrderId orderId) private {
+        _orderIds[orderKey] = orderId;
     }
 
     /**

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -509,7 +509,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         PoolKey memory key = placeData.key;
 
         // add the out of range liquidity to the pool
-        (BalanceDelta principalDelta, BalanceDelta feesAccrued) = poolManager.modifyLiquidity(
+        (BalanceDelta callerDelta, BalanceDelta feesAccrued) = poolManager.modifyLiquidity(
             key,
             ModifyLiquidityParams({
                 tickLower: placeData.tickLower,
@@ -527,25 +527,25 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             key.currency1.take(poolManager, address(this), amount1Fee = uint256(uint128(feesAccrued.amount1())), true);
         }
 
-        BalanceDelta delta = principalDelta - feesAccrued;
+        BalanceDelta principalDelta = callerDelta - feesAccrued;
 
         // if the amount of currency0 is negative, the limit order is to sell `currency0` for `currency1`
-        if (delta.amount0() < 0) {
+        if (principalDelta.amount0() < 0) {
             // if the amount of currency1 is not 0, the limit order is in range
-            if (delta.amount1() != 0) revert InRange();
+            if (principalDelta.amount1() != 0) revert InRange();
             // if `zeroForOne` is false, the limit order is wrong side of the range
             if (!placeData.zeroForOne) revert CrossedRange();
 
             // settle the currency0 to the owner
-            key.currency0.settle(poolManager, placeData.owner, uint256(uint128(-delta.amount0())), false);
+            key.currency0.settle(poolManager, placeData.owner, uint256(uint128(-principalDelta.amount0())), false);
         } else {
             // if the amount of currency0 is not 0, the limit order is in range
-            if (delta.amount0() != 0) revert InRange();
+            if (principalDelta.amount0() != 0) revert InRange();
             // if `zeroForOne` is true, the limit order is wrong side of the range
             if (placeData.zeroForOne) revert CrossedRange();
 
             // settle the currency1 to the owner
-            key.currency1.settle(poolManager, placeData.owner, uint256(uint128(-delta.amount1())), false);
+            key.currency1.settle(poolManager, placeData.owner, uint256(uint128(-principalDelta.amount1())), false);
         }
     }
 

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -27,11 +27,11 @@ import {BaseHook} from "../base/BaseHook.sol";
  *
  * Orders are identified by an OrderKey computed as a hash of its parameters. Multiple users can add liquidity
  * to the same OrderKey, sharing a single position owned by the hook. When an order is filled or completely
- * cancelled, the position is removed and users withdraw their liquidity.
+ * cancelled, the position is removed from the pool and users withdraw their liquidity.
  *
- * If users later place a new order at the same tick and direction, the OrderKey remains identical but maps
+ * If users later place a new order at the same order parameters, the OrderKey remains identical but maps
  * to a new OrderId. This ensures accounting state (currency totals, liquidity mappings, filled status) remains
- * independent between the original and subsequent orders.
+ * independent between the original and subsequent orders placed at the same pool location.
  *
  * NOTE: OrderKey identifies location and direction, while OrderId identifies the unique lifecycle instance.
  * An OrderKey may map to different OrderIds over time as orders are filled and recreated.
@@ -84,7 +84,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     using CurrencySettler for Currency;
     using SafeCast for *;
 
-    /// @dev The info for orders identified by OrderId.
+    /// @dev The info for each OrderId
     struct OrderInfo {
         /// @dev The currency0 of the order.
         Currency currency0;
@@ -100,9 +100,9 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         bool filled;
         /// @dev The liquidity of the order owned by each placer.
         mapping(address owner => uint128 amount) liquidity;
-        /// @dev Checkpoints of the `currency0Total` and `currency1Total` the last time the owner added liquidity
-        /// to the order, used as enhanced accounting to protect from accrued fees being stolen.
-        mapping(address owner => CheckpointCurrencies checkpoint) checkpoints;
+        /// @dev Checkpoints of the `currency0Total` and `currency1Total` (accrued fees) the last time the owner
+        /// added liquidity to the order, used as enhanced accounting to protect from accrued fees being stolen.
+        mapping(address owner => FeesCheckpointCurrencies feeCheckpoints) feeCheckpoints;
     }
 
     /// @dev Types of callbacks performed by the poolManager in `{unlockCallback}`
@@ -149,12 +149,12 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     }
 
     /**
-     * @dev Struct of checkpoint currencies. These are the amounts of `currency0` and `currency1` marked
+     * @dev Struct of fees checkpoint currencies. These are the amounts of `currency0` and `currency1` marked
      * as `currency0Total` and `currency1Total` in the `OrderInfo` struct at the time of the checkpoint.
      */
-    struct CheckpointCurrencies {
-        uint256 amountCurrency0;
-        uint256 amountCurrency1;
+    struct FeesCheckpointCurrencies {
+        uint256 currency0Fees;
+        uint256 currency1Fees;
     }
 
     /// @dev The zero bytes.
@@ -179,7 +179,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     /// @dev Zero liquidity was attempted to be added or removed.
     error ZeroLiquidity();
 
-    /// @dev Limit order was placed in an invalid range.
+    /// @dev Limit order was incorrectly placed in an invalid tick range.
     /// Note: limit orders can only be placed out of the current range as single side liquidity.
     error InvalidRange();
 
@@ -253,7 +253,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         return this.afterInitialize.selector;
     }
 
-    /// @dev Hooks into the `afterSwap` hook to get the ticks crossed by the swap and filling the crossed limit orders.
+    /// @dev Hooks into the `afterSwap` hook to get the ticks crossed by the swap and fills the crossed limit orders.
     function _afterSwap(address, PoolKey calldata key, SwapParams calldata params, BalanceDelta, bytes calldata)
         internal
         virtual
@@ -285,7 +285,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     function placeOrder(PoolKey calldata key, int24 tick, bool zeroForOne, uint128 liquidity) public payable virtual {
         if (liquidity == 0) revert ZeroLiquidity();
 
-        // the `msg.value` should be positive if the order is a native placement, and 0 otherwise
+        // the `msg.value` should be positive if the order is a native placement, 0 otherwise.
         if (key.currency0.isAddressZero() && zeroForOne) {
             if (msg.value == 0) revert InsufficientValue();
         } else if (msg.value != 0) {
@@ -321,13 +321,13 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             orderInfo.liquidity[msg.sender] += liquidity;
         }
 
-        // set the currency checkpoints for the msg.sender. These amounts are stored so that the user cannot steal
-        // fees accrued before the checkpoint. Note that the amounts in the checkpoints can only be from fees accrued,
-        // never from order fills, since thes checkpoint are updated only when the user places an order, and placing
-        // is only possible while the order is unfilled. This means possible fees accrued in between checkpoints are
-        // not taken into account, so the user is not entitled to them.
-        orderInfo.checkpoints[msg.sender].amountCurrency0 = orderInfo.currency0Total;
-        orderInfo.checkpoints[msg.sender].amountCurrency1 = orderInfo.currency1Total;
+        // Set the currency checkpoints for the `msg.sender`. These amounts are stored and considered at withdrawal time
+        // so that the user cannot steal fees accrued before the checkpoint. This means that any fees accrued in between
+        // checkpoints are deducted, so the user is not entitled to them.
+        // Note that the amounts in the checkpoints can only be from fees accrued, never from order fills,
+        // since the checkpoint are only updated at order placement, which is only possible while the order is unfilled.
+        orderInfo.feeCheckpoints[msg.sender].currency0Fees = orderInfo.currency0Total;
+        orderInfo.feeCheckpoints[msg.sender].currency1Fees = orderInfo.currency1Total;
 
         // unlock the callback to the poolManager, the callback will trigger `unlockCallback`
         // note that multiple functions trigger `unlockCallback`, so the `callbackData.callbackType` will determine what happens
@@ -464,16 +464,16 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         // get the total liquidity in the order
         uint128 liquidityTotal = orderInfo.liquidityTotal;
 
-        uint256 checkpointAmountCurrency0 = orderInfo.checkpoints[msg.sender].amountCurrency0;
-        uint256 checkpointAmountCurrency1 = orderInfo.checkpoints[msg.sender].amountCurrency1;
+        uint256 checkpointCurrency0Fees = orderInfo.feeCheckpoints[msg.sender].currency0Fees;
+        uint256 checkpointCurrency1Fees = orderInfo.feeCheckpoints[msg.sender].currency1Fees;
 
-        // calculate the amount of currency0 and currency1 owed to the msg.sender
-        // note that the user is not able to withdraw funds that were accrued before their checkpoint.
-        // `currencyTotals` at this point are the fill amounts + any accrued fees,
+        // Calculate the amount of currency0 and currency1 owed to the `msg.sender`.
+        // Note that the user is not entitled to withdraw fees that were accrued before their placing checkpoint.
+        // Since the order is filled, `currencyTotals` at this point consists of fill amounts + any accrued fees,
         // while `checkpoints` are the fees accrued before the withdrawer placed his order.
-        // therefore, `orderInfo.currency0Total - checkpointAmountCurrency0` gives us the exact amount owed to the withdrawer.
-        amount0 = FullMath.mulDiv(orderInfo.currency0Total - checkpointAmountCurrency0, liquidity, liquidityTotal);
-        amount1 = FullMath.mulDiv(orderInfo.currency1Total - checkpointAmountCurrency1, liquidity, liquidityTotal);
+        // Therefore, `currencyTotals` minus the `checkpoints` gives us the exact amount owed to the withdrawer.
+        amount0 = FullMath.mulDiv(orderInfo.currency0Total - checkpointCurrency0Fees, liquidity, liquidityTotal);
+        amount1 = FullMath.mulDiv(orderInfo.currency1Total - checkpointCurrency1Fees, liquidity, liquidityTotal);
 
         // subtract the amount of currency0 and currency1 from the order info
         orderInfo.currency0Total -= amount0;

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -108,6 +108,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     }
 
     /// @dev Types of callbacks performed by the poolManager in `{unlockCallback}`
+    /// NOTE: multiple external functions trigger `unlockCallback`, so the `CallbackType` determines the execution path.
     enum CallbackType {
         Place,
         Cancel,
@@ -315,11 +316,9 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         orderInfo.accruedFeesCheckpoints[msg.sender].currency0Fees = orderInfo.currency0Total;
         orderInfo.accruedFeesCheckpoints[msg.sender].currency1Fees = orderInfo.currency1Total;
 
-        // unlock the callback to the poolManager, the callback will trigger `unlockCallback`
-        // note that multiple functions trigger `unlockCallback`, so the `callbackData.callbackType` will determine what happens
-        // in `unlockCallback`. In this case, it will add liquidity out of range.
-        // IMPORTANT: `tick` must be valid, i.e. within the range of `MIN_TICK` and `MAX_TICK`, defined in the `TickMath` library and it must be
-        // a multiple of `key.tickSpacing`.
+        // Unlock the poolManager, which will call back this contract `unlockCallback`.
+        // IMPORTANT: `tick` must be valid, i.e. within the range of `MIN_TICK` and `MAX_TICK`, defined
+        // in the `TickMath` library and it must be a multiple of `key.tickSpacing`.
         (uint256 amount0Fee, uint256 amount1Fee) = abi.decode(
             poolManager.unlock(
                 abi.encode(
@@ -332,9 +331,6 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             (uint256, uint256)
         );
 
-        // add any accrued fees to the order info
-        // note that the currency totals must be updated after poolManager call as they depend on the returned values of the callback.
-        // This is safe as these functions are only callable on the trusted poolManager
         unchecked {
             // slither-disable-next-line reentrancy-no-eth
             orderInfo.currency0Total += amount0Fee;
@@ -354,6 +350,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      */
     function cancelOrder(PoolKey calldata key, int24 tickLower, bool zeroForOne, address to) public virtual {
         OrderIdLibrary.OrderId orderId = getOrderId(key, tickLower, zeroForOne);
+
         OrderInfo storage orderInfo = _orderInfos[orderId];
 
         if (orderInfo.filled) revert Filled();
@@ -362,16 +359,14 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
         if (liquidity == 0) revert ZeroLiquidity();
 
-        delete orderInfo.liquidity[msg.sender];
-
         bool removingAllLiquidity = liquidity == orderInfo.liquidityTotal;
+
+        delete orderInfo.liquidity[msg.sender];
         orderInfo.liquidityTotal -= liquidity;
 
-        // unlock the callback to the poolManager, the callback will trigger `unlockCallback`
-        // and remove the liquidity from the pool. Note that this function will return the fees accrued
-        // by the position, since the limit order is a liquidity addition.
+        // Unlock the poolManager, which will call back this contract `unlockCallback`.
         // Note that `amount0Fee` and `amount1Fee` are the fees accrued by the position and will not be transferred to
-        // the `to` address. Instead, they will be added to the order info (benefiting the remaining limit order placers).
+        // the `to` address. Instead, they are added to the order info (benefiting the remaining limit order placers).
         (uint256 amount0Fee, uint256 amount1Fee) = abi.decode(
             poolManager.unlock(
                 abi.encode(
@@ -399,9 +394,6 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             orderInfo.currency0Total = 0;
             orderInfo.currency1Total = 0;
         } else {
-            // add the fees to the order info
-            // note that the currency totals must be updated after poolManager call as they depend on the returned values of the callback.
-            // This is safe as these functions are only callable on the trusted poolManager
             unchecked {
                 // slither-disable-next-line reentrancy-no-eth
                 orderInfo.currency0Total += amount0Fee;
@@ -439,11 +431,10 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         uint256 checkpointCurrency0Fees = orderInfo.accruedFeesCheckpoints[msg.sender].currency0Fees;
         uint256 checkpointCurrency1Fees = orderInfo.accruedFeesCheckpoints[msg.sender].currency1Fees;
 
-        // Calculate the amount of currency0 and currency1 owed to the `msg.sender`.
-        // Note that the user is not entitled to withdraw fees that were accrued before their placing checkpoint.
-        // Since the order is filled, `currencyTotals` at this point consists of fill amounts plus any accrued fees,
-        // while `checkpoints` are the accrued fees that were registered when the withdrawer placed his order.
-        // Therefore, `currencyTotals` minus `checkpoints` is the exact amount owed to the withdrawer.
+        // Calculate amounts owed to `msg.sender`. `currencyTotals` contains fill amounts + all accrued fees,
+        // while `checkpoints` contains fees accrued at placement time.
+        // Therefore, (fills + all fees) - (pre-checkpoint fees) = fills + post-checkpoint fees, which is exactly what
+        // the withdrawer is entitled to.
         amount0 = FullMath.mulDiv(orderInfo.currency0Total - checkpointCurrency0Fees, liquidity, liquidityTotal);
         amount1 = FullMath.mulDiv(orderInfo.currency1Total - checkpointCurrency1Fees, liquidity, liquidityTotal);
 
@@ -452,8 +443,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
         orderInfo.liquidityTotal -= liquidity;
 
-        // unlock the callback to the poolManager, the callback will trigger `unlockCallback`
-        // and return the liquidity to the `to` address.
+        // Unlock the poolManager, which will call back this contract `unlockCallback`.
         poolManager.unlock(
             abi.encode(
                 CallbackData(
@@ -518,7 +508,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             ZERO_BYTES
         );
 
-        // collect the fees from the pool to the hook
+        // collect any fees from the pool to the hook
         if (feesAccrued.amount0() > 0) {
             placeData.key.currency0
                 .take(poolManager, address(this), amount0Fee = feesAccrued.amount0().toUint256(), true);
@@ -530,13 +520,14 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
         BalanceDelta principalDelta = callerDelta - feesAccrued;
 
-        // order swaps currency0 to currency1, therefore should only add currency0.
+        // if the order is zeroForOne, only single-side currency0 should be added.
         if (placeData.zeroForOne) {
             // if the order is not adding currency0, or currency1 is involved, the order is invalid
             if (principalDelta.amount0() >= 0 || principalDelta.amount1() != 0) revert InvalidRange();
 
-            // if the currency0 is native, refund any excess in the msg value
-            // Note that the poolManager is already protected from reentrancy via a reentrancy guard.
+            // if the currency0 is native, refund any excess in the `msg.value` if any
+            // NOTE: The poolManager is already protected from reentrancy via a reentrancy guard of it's own,
+            // and this function is only callable by the poolManager.
             if (placeData.key.currency0.isAddressZero()) {
                 int256 refundAmount = int256(placeData.value) - -(principalDelta.amount0());
                 if (refundAmount < 0) revert InsufficientValue();
@@ -546,12 +537,12 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
                 }
             }
 
-            // settle the currency0 from the sender to the pool
+            // settle the currency0 from the `msg.sender` to the pool
             placeData.key.currency0.settle(poolManager, placeData.owner, (-principalDelta.amount0()).toUint256(), false);
         } else {
-            // if the order is not adding currency1, or currency0 is involved, the order is invalid
+            // if the order is oneForZero, only single-side currency1 should be added.
             if (principalDelta.amount1() >= 0 || principalDelta.amount0() != 0) revert InvalidRange();
-            // settle the currency1 from the sender to the pool
+            // settle the currency1 from the `msg.sender` to the pool
             placeData.key.currency1.settle(poolManager, placeData.owner, (-principalDelta.amount1()).toUint256(), false);
         }
     }
@@ -607,7 +598,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             // so we can just use the `cancelDelta` as the principal delta (includes fees from this modifyLiquidity)
             principalDelta = callerDelta;
 
-            // also transfer previously accumulated fees (minted to hook by earlier cancellers)
+            // transfer previously accumulated fees (minted to hook by earlier cancellers)
             if (cancelData.accumulatedFees0 > 0) {
                 poolManager.burn(address(this), cancelData.key.currency0.toId(), cancelData.accumulatedFees0);
                 poolManager.take(cancelData.key.currency0, cancelData.to, cancelData.accumulatedFees0);
@@ -661,10 +652,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
         // if the order is not default (not initialized), fill it
         if (!orderId.equals(ORDER_ID_DEFAULT)) {
-            // get the order info
             OrderInfo storage orderInfo = _orderInfos[orderId];
 
-            // set the order as filled
             orderInfo.filled = true;
 
             // set the order as default (inactive)

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -69,12 +69,12 @@ library OrderIdLibrary {
  * have been accrued. In those cases, the accrued fees are added to the order info, benefitting the remaining
  * limit order placers.
  *
+ * NOTE: Since the PoolManager implements a ReentrancyGuard, {placeOrder, cancelOrder, withdraw} are already
+ * protected from reentrancy.
+ *
  * WARNING: This is experimental software and is provided on an "as is" and "as available" basis. We do
  * not give any warranties and will not be liable for any losses incurred through any use of this code
  * base.
- *
- * Note: since the PoolManager implements a ReentrancyGuard, {placeOrder, cancelOrder, withdraw} are already
- * protected from reentrancy.
  *
  * _Available since v1.1.0_
  */
@@ -90,9 +90,9 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         Currency currency0;
         /// @dev The currency1 of the order.
         Currency currency1;
-        /// @dev The total currency0 of the order including fees resting inactive in the hook.
+        /// @dev The total currency0 of the order from accrued fees or fills, resting inactive in the hook.
         uint256 currency0Total;
-        /// @dev The total currency1 of the order including fees resting inactive in the hook.
+        /// @dev The total currency1 of the order from accrued fees or fills, resting inactive in the hook.
         uint256 currency1Total;
         /// @dev The total liquidity of the order provided by all the limit order placers.
         uint128 liquidityTotal;
@@ -100,9 +100,11 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         bool filled;
         /// @dev The liquidity of the order owned by each placer.
         mapping(address owner => uint128 amount) liquidity;
-        /// @dev Checkpoints of the `currency0Total` and `currency1Total` (accrued fees) the last time the owner
-        /// added liquidity to the order, used as enhanced accounting to protect from accrued fees being stolen.
-        mapping(address owner => FeesCheckpointCurrencies feeCheckpoints) feeCheckpoints;
+        /// @dev Tracks `currency0Total` and `currency1Total` at the time each owner adds liquidity to an order.
+        /// At withdrawal, fees accrued before the checkpoint are deducted to prevent owners from claiming fees
+        /// they're not entitled to.
+        /// NOTE: Only updated on order placement (while unfilled), so checkpoints never include order fills.
+        mapping(address owner => AccruedFeesCheckpoint accruedFeesCheckpoint) accruedFeesCheckpoints;
     }
 
     /// @dev Types of callbacks performed by the poolManager in `{unlockCallback}`
@@ -148,11 +150,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         address to;
     }
 
-    /**
-     * @dev Struct of fees checkpoint currencies. These are the amounts of `currency0` and `currency1` marked
-     * as `currency0Total` and `currency1Total` in the `OrderInfo` struct at the time of the checkpoint.
-     */
-    struct FeesCheckpointCurrencies {
+    /// @dev Struct of accrued fees checkpoint.
+    struct AccruedFeesCheckpoint {
         uint256 currency0Fees;
         uint256 currency1Fees;
     }
@@ -180,7 +179,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     error ZeroLiquidity();
 
     /// @dev Limit order was incorrectly placed in an invalid tick range.
-    /// Note: limit orders can only be placed out of the current range as single side liquidity.
+    /// NOTE: limit orders can only be placed out of the current range as single side liquidity.
     error InvalidRange();
 
     /// @dev Limit order was already filled.
@@ -236,8 +235,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     );
 
     /**
-     * @dev Emitted when an `owner` withdraws their `liquidity` from a limit order with the given `orderId`, in the pool identified by `key`,
-     * at the given `tickLower`, `zeroForOne` indicating the direction of the order.
+     * @dev Emitted when an `owner` withdraws their `liquidity` from a limit order with the given `orderId`, in
+     * the pool identified by `key`, at the given `tickLower`, `zeroForOne` indicating the direction of the order.
      */
     event Withdraw(address indexed owner, OrderIdLibrary.OrderId indexed orderId, uint128 liquidity);
 
@@ -253,7 +252,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         return this.afterInitialize.selector;
     }
 
-    /// @dev Hooks into the `afterSwap` hook to get the ticks crossed by the swap and fills the crossed limit orders.
+    /// @dev Hooks into the `afterSwap` hook to get the ticks crossed by the swap, filling the crossed limit orders.
     function _afterSwap(address, PoolKey calldata key, SwapParams calldata params, BalanceDelta, bytes calldata)
         internal
         virtual
@@ -264,7 +263,6 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
         if (lower > upper) return (this.afterSwap.selector, 0);
 
-        // set the last tick lower for the pool
         _tickLowerLasts[key.toId()] = tickLower;
 
         for (; lower <= upper; lower += key.tickSpacing) {
@@ -279,20 +277,17 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     /**
      * @dev Places a limit order by adding liquidity out of range at a specific tick. The order will be filled when the
      * pool price crosses the specified `tick`. Takes a `PoolKey` `key`, target `tick`, direction `zeroForOne` indicating
-     * whether to buy currency0 or currency1, and amount of `liquidity` to place. The interaction with the `poolManager` is done
-     * via the `unlock` function, which will trigger the `{unlockCallback}` function.
+     * whether to buy currency0 or currency1, and amount of `liquidity` to place. The interaction with the `poolManager` is
+     * done via the `unlock` function, which will trigger the `{unlockCallback}` function.
      */
     function placeOrder(PoolKey calldata key, int24 tick, bool zeroForOne, uint128 liquidity) public payable virtual {
         if (liquidity == 0) revert ZeroLiquidity();
 
-        // the `msg.value` should be positive if the order is a native placement, 0 otherwise.
-        if (key.currency0.isAddressZero() && zeroForOne) {
-            if (msg.value == 0) revert InsufficientValue();
-        } else if (msg.value != 0) {
+        // the `msg.value` should be positive only if the order is a native placement
+        if (!(key.currency0.isAddressZero() && zeroForOne) && msg.value != 0) {
             revert InvalidValue();
         }
 
-        // get the OrderKey and it's associated OrderId
         bytes32 orderKey = getOrderKey(key, tick, zeroForOne);
         OrderIdLibrary.OrderId orderId = getOrderId(orderKey);
 
@@ -306,28 +301,19 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             }
 
             orderInfo = _orderInfos[orderId];
-
-            // set the order currencies
             orderInfo.currency0 = key.currency0;
             orderInfo.currency1 = key.currency1;
         } else {
-            // get the order info
             orderInfo = _orderInfos[orderId];
         }
 
-        // add the liquidity to the order
         unchecked {
             orderInfo.liquidityTotal += liquidity;
             orderInfo.liquidity[msg.sender] += liquidity;
         }
 
-        // Set the currency checkpoints for the `msg.sender`. These amounts are stored and considered at withdrawal time
-        // so that the user cannot steal fees accrued before the checkpoint. This means that any fees accrued in between
-        // checkpoints are deducted, so the user is not entitled to them.
-        // Note that the amounts in the checkpoints can only be from fees accrued, never from order fills,
-        // since the checkpoint are only updated at order placement, which is only possible while the order is unfilled.
-        orderInfo.feeCheckpoints[msg.sender].currency0Fees = orderInfo.currency0Total;
-        orderInfo.feeCheckpoints[msg.sender].currency1Fees = orderInfo.currency1Total;
+        orderInfo.accruedFeesCheckpoints[msg.sender].currency0Fees = orderInfo.currency0Total;
+        orderInfo.accruedFeesCheckpoints[msg.sender].currency1Fees = orderInfo.currency1Total;
 
         // unlock the callback to the poolManager, the callback will trigger `unlockCallback`
         // note that multiple functions trigger `unlockCallback`, so the `callbackData.callbackType` will determine what happens
@@ -356,7 +342,6 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             orderInfo.currency1Total += amount1Fee;
         }
 
-        // emit the place event
         emit Place(msg.sender, orderId, key, tick, zeroForOne, liquidity);
     }
 
@@ -368,24 +353,18 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      * The interaction with the `poolManager` is done via the `unlock` function, which will trigger the `{unlockCallback}` function.
      */
     function cancelOrder(PoolKey calldata key, int24 tickLower, bool zeroForOne, address to) public virtual {
-        // get the OrderId and it's associated OrderInfo
         OrderIdLibrary.OrderId orderId = getOrderId(key, tickLower, zeroForOne);
         OrderInfo storage orderInfo = _orderInfos[orderId];
 
-        // revert if the order is already filled
         if (orderInfo.filled) revert Filled();
 
-        // get the liquidity added by the msg.sender
         uint128 liquidity = orderInfo.liquidity[msg.sender];
 
-        // revert if the liquidity is 0
         if (liquidity == 0) revert ZeroLiquidity();
 
-        // delete the liquidity from the order
         delete orderInfo.liquidity[msg.sender];
 
         bool removingAllLiquidity = liquidity == orderInfo.liquidityTotal;
-        // subtract the liquidity from the total liquidity
         orderInfo.liquidityTotal -= liquidity;
 
         // unlock the callback to the poolManager, the callback will trigger `unlockCallback`
@@ -431,7 +410,6 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             }
         }
 
-        // emit the cancel event
         emit Cancel(msg.sender, orderId, key, tickLower, zeroForOne, liquidity);
     }
 
@@ -446,40 +424,32 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         virtual
         returns (uint256 amount0, uint256 amount1)
     {
-        // get the order info
         OrderInfo storage orderInfo = _orderInfos[orderId];
 
-        // revert if the order is not filled
         if (!orderInfo.filled) revert NotFilled();
 
-        // get the liquidity added by the msg.sender
         uint128 liquidity = orderInfo.liquidity[msg.sender];
 
-        // revert if the sender liquidity is 0
         if (liquidity == 0) revert ZeroLiquidity();
 
-        // delete the sender liquidity from the order
         delete orderInfo.liquidity[msg.sender];
 
-        // get the total liquidity in the order
         uint128 liquidityTotal = orderInfo.liquidityTotal;
 
-        uint256 checkpointCurrency0Fees = orderInfo.feeCheckpoints[msg.sender].currency0Fees;
-        uint256 checkpointCurrency1Fees = orderInfo.feeCheckpoints[msg.sender].currency1Fees;
+        uint256 checkpointCurrency0Fees = orderInfo.accruedFeesCheckpoints[msg.sender].currency0Fees;
+        uint256 checkpointCurrency1Fees = orderInfo.accruedFeesCheckpoints[msg.sender].currency1Fees;
 
         // Calculate the amount of currency0 and currency1 owed to the `msg.sender`.
         // Note that the user is not entitled to withdraw fees that were accrued before their placing checkpoint.
-        // Since the order is filled, `currencyTotals` at this point consists of fill amounts + any accrued fees,
-        // while `checkpoints` are the fees accrued before the withdrawer placed his order.
-        // Therefore, `currencyTotals` minus the `checkpoints` gives us the exact amount owed to the withdrawer.
+        // Since the order is filled, `currencyTotals` at this point consists of fill amounts plus any accrued fees,
+        // while `checkpoints` are the accrued fees that were registered when the withdrawer placed his order.
+        // Therefore, `currencyTotals` minus `checkpoints` is the exact amount owed to the withdrawer.
         amount0 = FullMath.mulDiv(orderInfo.currency0Total - checkpointCurrency0Fees, liquidity, liquidityTotal);
         amount1 = FullMath.mulDiv(orderInfo.currency1Total - checkpointCurrency1Fees, liquidity, liquidityTotal);
 
-        // subtract the amount of currency0 and currency1 from the order info
         orderInfo.currency0Total -= amount0;
         orderInfo.currency1Total -= amount1;
 
-        // update total liquidity
         orderInfo.liquidityTotal -= liquidity;
 
         // unlock the callback to the poolManager, the callback will trigger `unlockCallback`

--- a/test/general/LimitOrderHook.native.fuzz.t.sol
+++ b/test/general/LimitOrderHook.native.fuzz.t.sol
@@ -78,7 +78,7 @@ contract LimitOrderHookNativeTest is HookTest {
     // @dev Bound the tick lower for the limit order.
     function boundTickLower(PoolKey memory key, int24 tickLower, int24 tickDistance) public view returns (int24) {
         int24 currentTick = getCurrentTick(key.toId());
-        // tick should be not far away from the current tick, as otherwise enourmous swaps are required to reach the order range
+        // tick should be not far away from the current tick, as otherwise enormous swaps are required to reach the order range
         tickLower = int24(bound(tickLower, currentTick - tickDistance, currentTick + tickDistance));
         // tick should not breach the limits of the curve
         tickLower = int24(bound(tickLower, TickMath.MIN_TICK + key.tickSpacing, TickMath.MAX_TICK - key.tickSpacing));
@@ -322,7 +322,7 @@ contract LimitOrderHookNativeTest is HookTest {
             uint256 lp2Balance0Before = key.currency0.balanceOf(address(lp2));
             uint256 lp2Balance1Before = key.currency1.balanceOf(address(lp2));
 
-            // lp2 cancells, receiving all the fees accrued and deleting the order.
+            // lp2 cancels, receiving all the fees accrued and deleting the order.
             vm.prank(lp2);
             hook.cancelOrder(key, tickLower, zeroForOne, address(lp2));
 

--- a/test/general/LimitOrderHook.native.fuzz.t.sol
+++ b/test/general/LimitOrderHook.native.fuzz.t.sol
@@ -1,0 +1,536 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {CurrencyLibrary} from "@uniswap/v4-core/src/types/Currency.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IERC20Minimal} from "@uniswap/v4-core/src/interfaces/external/IERC20Minimal.sol";
+import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {Position} from "@uniswap/v4-core/src/libraries/Position.sol";
+// Internal imports
+import {LimitOrderHook, OrderIdLibrary} from "src/general/LimitOrderHook.sol";
+import {LimitOrderHookMock} from "../../src/mocks/general/LimitOrderHookMock.sol";
+import {HookTest} from "../utils/HookTest.sol";
+
+contract LimitOrderHookNativeTest is HookTest {
+    using StateLibrary for IPoolManager;
+    using CurrencyLibrary for Currency;
+
+    LimitOrderHookMock hook;
+
+    address lp1 = makeAddr("lp1");
+    address lp2 = makeAddr("lp2");
+    address attacker = makeAddr("attacker");
+    address swapper = makeAddr("swapper");
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+
+        Currency currency0 = Currency.wrap(address(0));
+
+        hook = LimitOrderHookMock(address(uint160(Hooks.AFTER_INITIALIZE_FLAG | Hooks.AFTER_SWAP_FLAG)));
+
+        deployCodeTo(
+            "src/mocks/general/LimitOrderHookMock.sol:LimitOrderHookMock", abi.encode(address(manager)), address(hook)
+        );
+
+        (key,) = initPool(currency0, currency1, IHooks(address(hook)), 3000, SQRT_PRICE_1_1);
+
+        vm.deal(address(this), 1e50);
+        vm.deal(lp1, 1e30);
+        vm.deal(lp2, 1e30);
+        vm.deal(swapper, 1e30);
+        vm.deal(attacker, 1e30);
+        IERC20Minimal(Currency.unwrap(currency1)).transfer(address(this), 1e50);
+        IERC20Minimal(Currency.unwrap(currency1)).transfer(lp1, 1e30);
+        IERC20Minimal(Currency.unwrap(currency1)).transfer(lp2, 1e30);
+        IERC20Minimal(Currency.unwrap(currency1)).transfer(swapper, 1e30);
+        IERC20Minimal(Currency.unwrap(currency1)).transfer(attacker, 1e30);
+
+        IERC20Minimal(Currency.unwrap(currency1)).approve(address(hook), type(uint256).max);
+        IERC20Minimal(Currency.unwrap(currency1)).approve(address(modifyLiquidityRouter), type(uint256).max);
+
+        vm.prank(lp1);
+        IERC20Minimal(Currency.unwrap(currency1)).approve(address(hook), type(uint256).max);
+        IERC20Minimal(Currency.unwrap(currency1)).approve(address(modifyLiquidityRouter), type(uint256).max);
+
+        vm.prank(lp2);
+        IERC20Minimal(Currency.unwrap(currency1)).approve(address(hook), type(uint256).max);
+        IERC20Minimal(Currency.unwrap(currency1)).approve(address(modifyLiquidityRouter), type(uint256).max);
+
+        vm.prank(swapper);
+        IERC20Minimal(Currency.unwrap(currency1)).approve(address(swapRouter), type(uint256).max);
+
+        vm.prank(attacker);
+        IERC20Minimal(Currency.unwrap(currency1)).approve(address(hook), type(uint256).max);
+        IERC20Minimal(Currency.unwrap(currency1)).approve(address(modifyLiquidityRouter), type(uint256).max);
+        IERC20Minimal(Currency.unwrap(currency1)).approve(address(swapRouter), type(uint256).max);
+
+        vm.label(Currency.unwrap(currency0), "currency0");
+        vm.label(Currency.unwrap(currency1), "currency1");
+    }
+
+    // @dev Bound the tick lower for the limit order.
+    function boundTickLower(PoolKey memory key, int24 tickLower, int24 tickDistance) public view returns (int24) {
+        int24 currentTick = getCurrentTick(key.toId());
+        // tick should be not far away from the current tick, as otherwise enourmous swaps are required to reach the order range
+        tickLower = int24(bound(tickLower, currentTick - tickDistance, currentTick + tickDistance));
+        // tick should not breach the limits of the curve
+        tickLower = int24(bound(tickLower, TickMath.MIN_TICK + key.tickSpacing, TickMath.MAX_TICK - key.tickSpacing));
+        // tick should be a multiple of tick spacing
+        tickLower = flooredTick(tickLower, key.tickSpacing);
+        return tickLower;
+    }
+
+    // @dev Overload the boundTickLower function with a default tick distance of 3000.
+    function boundTickLower(PoolKey memory key, int24 tickLower) public view returns (int24) {
+        int24 tickDistance = 3000; // ~50% (1x) price range
+        return boundTickLower(key, tickLower, tickDistance);
+    }
+
+    // @dev Verify if the limit order is out of range as it should be.
+    // Note: a limit order must be placed out of the current range as single side liquidity.
+    function isValidLimitOrderRange(PoolKey memory key, bool zeroForOne, int24 tickLower) public view returns (bool) {
+        int24 tickUpper = tickLower + key.tickSpacing;
+        int24 currentTick = getCurrentTick(key.toId());
+        // if the order is zeroForOne, it must be placed to the right of the current tick
+        // if the order is oneForZero, it must be placed to the left of the current tick
+        return zeroForOne ? tickLower >= currentTick : tickUpper <= currentTick;
+    }
+
+    function testFuzz_placeOrder_zeroLiquidity_reverts(int24 tickLower, bool zeroForOne) public {
+        tickLower = boundTickLower(key, tickLower);
+
+        bool isValidRange = isValidLimitOrderRange(key, zeroForOne, tickLower);
+        vm.assume(isValidRange);
+
+        vm.expectRevert(LimitOrderHook.ZeroLiquidity.selector);
+        vm.prank(lp1);
+        hook.placeOrder{value: 0}(key, tickLower, zeroForOne, 0);
+    }
+
+    function testFuzz_placeOrder_InvalidNativeValue_reverts(int24 tickLower, bool zeroForOne, uint128 liquidity)
+        public
+    {
+        tickLower = boundTickLower(key, tickLower);
+        liquidity = uint128(bound(liquidity, 1e8, 1e26));
+        vm.assume(isValidLimitOrderRange(key, zeroForOne, tickLower));
+
+        if (zeroForOne) {
+            vm.expectEmit(true, true, true, true);
+            emit LimitOrderHook.Place(lp1, OrderIdLibrary.OrderId.wrap(1), key, tickLower, zeroForOne, liquidity);
+        } else {
+            vm.expectRevert(LimitOrderHook.InvalidValue.selector);
+        }
+
+        vm.prank(lp1);
+        hook.placeOrder{value: liquidity}(key, tickLower, zeroForOne, liquidity);
+    }
+
+    function testFuzz_placeOrder_InsufficientNativeValue_reverts(int24 tickLower, bool zeroForOne, uint128 liquidity)
+        public
+    {
+        tickLower = boundTickLower(key, tickLower);
+        liquidity = uint128(bound(liquidity, 1e8, 1e26));
+        vm.assume(isValidLimitOrderRange(key, zeroForOne, tickLower));
+
+        if (zeroForOne) {
+            vm.expectRevert(LimitOrderHook.InsufficientValue.selector);
+        } else {
+            vm.expectEmit(true, true, true, true);
+            emit LimitOrderHook.Place(lp1, OrderIdLibrary.OrderId.wrap(1), key, tickLower, zeroForOne, liquidity);
+        }
+
+        vm.prank(lp1);
+        hook.placeOrder{value: 0}(key, tickLower, zeroForOne, liquidity);
+    }
+
+    function testFuzz_placeOrder(int24 tickLower, bool zeroForOne, uint128 liquidity) public {
+        liquidity = uint128(bound(uint256(liquidity), 1, 1e26));
+        tickLower = boundTickLower(key, tickLower);
+
+        bool isValidRange = isValidLimitOrderRange(key, zeroForOne, tickLower);
+
+        (uint256 amount0Expected, uint256 amount1Expected) = calculateAmountsForLiquidity(key, tickLower, liquidity);
+
+        uint256 balance0Before = key.currency0.balanceOf(address(lp1));
+        uint256 balance1Before = key.currency1.balanceOf(address(lp1));
+
+        if (isValidRange) {
+            vm.expectEmit(true, true, true, true);
+            emit LimitOrderHook.Place(lp1, OrderIdLibrary.OrderId.wrap(1), key, tickLower, zeroForOne, liquidity);
+        } else {
+            vm.expectRevert(LimitOrderHook.InvalidRange.selector);
+        }
+
+        vm.prank(lp1);
+        hook.placeOrder{value: zeroForOne ? liquidity : 0}(key, tickLower, zeroForOne, liquidity);
+
+        uint256 balance0After = key.currency0.balanceOf(address(lp1));
+        uint256 balance1After = key.currency1.balanceOf(address(lp1));
+
+        if (isValidRange) {
+            assertTrue(
+                OrderIdLibrary.equals(hook.getOrderId(key, tickLower, zeroForOne), OrderIdLibrary.OrderId.wrap(1)),
+                "orderId should have been assigned"
+            );
+
+            bytes32 positionId = Position.calculatePositionKey(address(hook), tickLower, tickLower + key.tickSpacing, 0);
+            assertEq(
+                manager.getPositionLiquidity(key.toId(), positionId),
+                liquidity,
+                "the liquidity position should have the expected liquidity"
+            );
+
+            uint256 lpOrderLiquidity = hook.getOrderLiquidity(OrderIdLibrary.OrderId.wrap(1), address(lp1));
+            assertEq(lpOrderLiquidity, liquidity, "lp should own the expected liquidity on the order");
+
+            (bool filled,,, uint256 currency0Total, uint256 currency1Total, uint256 liquidityTotal) =
+                hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+            assertFalse(filled, "order should not be filled");
+            assertEq(currency0Total, 0, "currency0Total should be 0");
+            assertEq(currency1Total, 0, "currency1Total should be 0");
+            assertEq(liquidityTotal, liquidity, "liquidityTotal should be the liquidity");
+
+            assertApproxEqAbs(
+                balance0Before - balance0After,
+                amount0Expected,
+                1,
+                "lp should have paid the expected amount of currency0"
+            );
+            assertApproxEqAbs(
+                balance1Before - balance1After,
+                amount1Expected,
+                1,
+                "lp should have paid the expected amount of currency1"
+            );
+        } else {
+            assertTrue(
+                OrderIdLibrary.equals(hook.getOrderId(key, tickLower, zeroForOne), OrderIdLibrary.OrderId.wrap(0)),
+                "order should should have the default order id"
+            );
+            assertEq(
+                hook.getOrderLiquidity(OrderIdLibrary.OrderId.wrap(0), address(lp1)), 0, "order should have 0 liquidity"
+            );
+        }
+    }
+
+    function testFuzz_feesAccrued_unfilled(int24 tickLower, bool zeroForOne, uint128 liquidity) public {
+        tickLower = boundTickLower(key, tickLower);
+        liquidity = uint128(bound(liquidity, 1e8, 1e26));
+
+        {
+            bool isValidRange = isValidLimitOrderRange(key, zeroForOne, tickLower);
+            vm.assume(isValidRange);
+
+            uint256 amountToSwap = liquidity / 1e4; // swapper swaps 1/1000 of the liquidity.
+
+            // the two lps place orders.
+            vm.prank(lp1);
+            hook.placeOrder{value: zeroForOne ? liquidity : 0}(key, tickLower, zeroForOne, liquidity);
+            vm.prank(lp2);
+            hook.placeOrder{value: zeroForOne ? liquidity : 0}(key, tickLower, zeroForOne, liquidity);
+
+            // each lp should own the expected liquidity on the order.
+            assertEq(
+                hook.getOrderLiquidity(OrderIdLibrary.OrderId.wrap(1), address(lp1)), liquidity, "lp1 owns liquidity"
+            );
+            assertEq(
+                hook.getOrderLiquidity(OrderIdLibrary.OrderId.wrap(1), address(lp2)), liquidity, "lp2 owns liquidity"
+            );
+
+            // the swapper swaps, moving the price into the range of the orders.
+            vm.prank(swapper);
+            if (zeroForOne) {
+                // if the order is zeroForOne, swap in the oneForZero direction to accrue fees to the order.
+                swap(key, false, int256(amountToSwap), "");
+            } else {
+                // if the order is oneForZero, swap in the zeroForOne direction to accrue fees to the order.
+                swapNativeInput(key, true, int256(amountToSwap), "", amountToSwap * 10); // 10x buffer on `msg.value` that is refunded
+            }
+
+            // assume the swap moved the price inside the order range.
+            int24 currentTick = getCurrentTick(key.toId());
+            vm.assume(currentTick > tickLower && currentTick < tickLower + key.tickSpacing);
+
+            // verify the order state after the swap.
+            (bool filled,,, uint256 currency0Total, uint256 currency1Total, uint256 liquidityTotal) =
+                hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+            assertFalse(filled, "order should not be filled");
+            assertEq(currency0Total, 0, "currency0Total should be 0");
+            assertEq(currency1Total, 0, "currency1Total should be 0");
+            assertEq(liquidityTotal, liquidity * 2, "liquidityTotal should be 2 * liquidity");
+        }
+
+        {
+            // withdrawing: should fail as the order is not filled.
+            vm.expectRevert(LimitOrderHook.NotFilled.selector);
+            vm.prank(lp1);
+            hook.withdraw(OrderIdLibrary.OrderId.wrap(1), address(lp1));
+
+            // placing: should fail as the order is now in range.
+            vm.expectRevert(LimitOrderHook.InvalidRange.selector);
+            vm.prank(lp1);
+            hook.placeOrder{value: zeroForOne ? liquidity : 0}(key, tickLower, zeroForOne, liquidity);
+        }
+
+        // calculate the fees accrued to the order.
+        (int128 fees0, int128 fees1) =
+            calculateFees(manager, key.toId(), address(hook), tickLower, tickLower + key.tickSpacing, 0);
+        assertTrue(fees0 > 0 || fees1 > 0, "there should be fees accrued");
+
+        // cancelling: should succeed, fees should only be allocated to the last canceller.
+        {
+            uint256 lp1Balance0Before = key.currency0.balanceOf(address(lp1));
+            uint256 lp1Balance1Before = key.currency1.balanceOf(address(lp1));
+
+            vm.prank(lp1);
+            hook.cancelOrder(key, tickLower, zeroForOne, address(lp1));
+
+            uint256 lp1Balance0After = key.currency0.balanceOf(address(lp1));
+            uint256 lp1Balance1After = key.currency1.balanceOf(address(lp1));
+
+            {
+                // lp1 should have cancelled
+                (bool filled,,, uint256 currency0Total, uint256 currency1Total, uint256 liquidityTotal) =
+                    hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+                assertFalse(filled, "order should not be filled");
+                assertEq(currency0Total, uint256(uint128(fees0)), "currency0Total should be the fees accrued");
+                assertEq(currency1Total, uint256(uint128(fees1)), "currency1Total should be the fees accrued");
+                assertEq(liquidityTotal, liquidity, "liquidityTotal should be 1 * liquidity");
+            }
+
+            // preview the liquidity to amounts
+            (uint256 amount0Expected, uint256 amount1Expected) = calculateAmountsForLiquidity(key, tickLower, liquidity);
+
+            // lp1 should have received only the liquidity without any fees accrued.
+            assertEq(
+                hook.getOrderLiquidity(OrderIdLibrary.OrderId.wrap(1), address(lp1)),
+                0,
+                "lp1 should own 0 liquidity in the order"
+            );
+            assertEq(lp1Balance0After - lp1Balance0Before, amount0Expected, "lp1 should have received the amount0");
+            assertEq(lp1Balance1After - lp1Balance1Before, amount1Expected, "lp1 should have received the amount1");
+        }
+
+        {
+            uint256 lp2Balance0Before = key.currency0.balanceOf(address(lp2));
+            uint256 lp2Balance1Before = key.currency1.balanceOf(address(lp2));
+
+            // lp2 cancells, receiving all the fees accrued and deleting the order.
+            vm.prank(lp2);
+            hook.cancelOrder(key, tickLower, zeroForOne, address(lp2));
+
+            uint256 lp2Balance0After = key.currency0.balanceOf(address(lp2));
+            uint256 lp2Balance1After = key.currency1.balanceOf(address(lp2));
+
+            // verify the order state after the last canceller's cancellation.
+            {
+                (bool filled,,, uint256 currency0Total, uint256 currency1Total, uint256 liquidityTotal) =
+                    hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+                assertFalse(filled, "order should not be filled");
+                assertEq(currency0Total, 0, "currency0Total should be zero");
+                assertEq(currency1Total, 0, "currency1Total should be zero");
+                assertEq(liquidityTotal, 0, "liquidityTotal should be 0");
+            }
+
+            // the order id should be reset.
+            assertTrue(
+                OrderIdLibrary.equals(hook.getOrderId(key, tickLower, zeroForOne), OrderIdLibrary.OrderId.wrap(0)),
+                "order should should have the default order id"
+            );
+
+            // lp2 should have received the liquidity plus all the fees accrued.
+            assertEq(
+                hook.getOrderLiquidity(OrderIdLibrary.OrderId.wrap(1), address(lp2)),
+                0,
+                "lp2 should own 0 liquidity in the order"
+            );
+
+            // preview the liquidity to amounts
+            (uint256 amount0Expected, uint256 amount1Expected) = calculateAmountsForLiquidity(key, tickLower, liquidity);
+
+            // lp2 receives their liquidity plus all the accumulated fees
+            assertEq(
+                lp2Balance0After - lp2Balance0Before,
+                amount0Expected + uint256(uint128(fees0)),
+                "lp2 should have received the amount0 + fees0"
+            );
+            assertEq(
+                lp2Balance1After - lp2Balance1Before,
+                amount1Expected + uint256(uint128(fees1)),
+                "lp2 should have received the amount1 + fees1"
+            );
+        }
+    }
+
+    function testFuzz_feesAccrued_filled_native(int24 tickLower, bool zeroForOne, uint128 liquidity) public {
+        tickLower = boundTickLower(key, tickLower, 1000);
+        liquidity = uint128(bound(liquidity, 1e8, 1e26));
+
+        {
+            bool isValidRange = isValidLimitOrderRange(key, zeroForOne, tickLower);
+            vm.assume(isValidRange);
+
+            // the two lps place orders.
+            vm.prank(lp1);
+            hook.placeOrder{value: zeroForOne ? liquidity : 0}(key, tickLower, zeroForOne, liquidity);
+            vm.prank(lp2);
+            hook.placeOrder{value: zeroForOne ? liquidity : 0}(key, tickLower, zeroForOne, liquidity);
+
+            // each lp should own the expected liquidity on the order.
+            assertEq(
+                hook.getOrderLiquidity(OrderIdLibrary.OrderId.wrap(1), address(lp1)), liquidity, "lp1 owns liquidity"
+            );
+            assertEq(
+                hook.getOrderLiquidity(OrderIdLibrary.OrderId.wrap(1), address(lp2)), liquidity, "lp2 owns liquidity"
+            );
+
+            // Calculate a safe resistance liquidity that won't overflow
+            // Use a fixed large value (1e24) to avoid overflow while still providing enough resistance
+            uint128 resistanceLiquidity = 1e24;
+
+            // Place a massive resistance order BEYOND the tested order to stop price explosion
+            // This prevents the swap from iterating through thousands of ticks
+            int24 resistanceTick = zeroForOne ? tickLower + key.tickSpacing : tickLower - key.tickSpacing;
+            hook.placeOrder{value: zeroForOne ? resistanceLiquidity : 0}(
+                key, resistanceTick, zeroForOne, resistanceLiquidity
+            );
+        }
+        {
+            // Use 2x liquidity for swap to ensure the order is filled
+            uint256 amountToSwap = liquidity * 2;
+
+            // the swapper swaps into the range of the orders.
+            vm.prank(swapper);
+            if (zeroForOne) {
+                // if the order is zeroForOne, swap in the oneForZero direction to accrue fees to the order.
+                swap(key, false, int256(amountToSwap), "");
+            } else {
+                // if the order is oneForZero, swap in the zeroForOne direction to accrue fees to the order.
+                swapNativeInput(key, true, int256(amountToSwap), "", amountToSwap * 10); // 10x buffer on `msg.value` that is refunded
+            }
+        }
+        {
+            // calculate the currency0 and currency1 given the liquidity provided.
+            (uint256 amount0Expected, uint256 amount1Expected) = calculateAmountsForLiquidity(key, tickLower, liquidity);
+
+            // assume the swap crossed the order range, filling the order.
+            // verify the order state after the swap
+            (bool filled,,, uint256 currency0Total, uint256 currency1Total, uint256 liquidityTotal) =
+                hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+            vm.assume(filled);
+            // note: there is no easy way to fetch the fees accrued, since they are now stored in the hook altogether
+            // within the currency0Total and currency1Total.
+            if (zeroForOne) {
+                assertGe(currency1Total, amount1Expected, "currency1Total should be liquidity plus fees accrued");
+            } else {
+                assertGe(currency0Total, amount0Expected, "currency0Total should be liquidity plus fees accrued");
+            }
+
+            assertEq(liquidityTotal, liquidity * 2, "liquidityTotal should be 2 * liquidity");
+            assertTrue(
+                OrderIdLibrary.equals(hook.getOrderId(key, tickLower, zeroForOne), OrderIdLibrary.OrderId.wrap(0)),
+                "order should should have the default order id (0)"
+            );
+
+            {
+                // placing: would work if the price moved out of range again, but it would
+                // a new order id (2), and therefore is no way to place at order id 1.
+                vm.expectRevert(LimitOrderHook.InvalidRange.selector);
+                vm.prank(lp1);
+                hook.placeOrder{value: zeroForOne ? liquidity : 0}(key, tickLower, zeroForOne, liquidity);
+            }
+
+            {
+            // cancelling: there is no way to cancel the order id 1 as the orderId has been incremented.
+            }
+
+            {
+                // first lp withdraws
+                uint256 lp1Balance0Before = key.currency0.balanceOf(address(lp1));
+                uint256 lp1Balance1Before = key.currency1.balanceOf(address(lp1));
+
+                vm.prank(lp1);
+                hook.withdraw(OrderIdLibrary.OrderId.wrap(1), address(lp1));
+
+                uint256 lp1Balance0After = key.currency0.balanceOf(address(lp1));
+                uint256 lp1Balance1After = key.currency1.balanceOf(address(lp1));
+
+                (
+                    ,,,
+                    uint256 currency0TotalAfterLp1Withdraw,
+                    uint256 currency1TotalAfterLp1Withdraw,
+                    uint256 liquidityTotalAfterLp1Withdraw
+                ) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+                assertApproxEqAbs(
+                    currency0TotalAfterLp1Withdraw,
+                    currency0Total / 2,
+                    1,
+                    "currency0Total after lp1 withdraw should be half"
+                );
+                assertApproxEqAbs(
+                    currency1TotalAfterLp1Withdraw,
+                    currency1Total / 2,
+                    1,
+                    "currency1Total after lp1 withdraw should be half"
+                );
+                assertEq(
+                    liquidityTotalAfterLp1Withdraw, liquidity, "liquidityTotal after lp1 withdraw should be liquidity"
+                );
+
+                // lp1 should have received currency0Total/2 and currency1Total/2
+                assertEq(
+                    lp1Balance0After - lp1Balance0Before,
+                    currency0Total / 2,
+                    "lp1 should have received half of the currency1Total"
+                );
+                assertEq(
+                    lp1Balance1After - lp1Balance1Before,
+                    currency1Total / 2,
+                    "lp1 should have received half of the currency0Total"
+                );
+            }
+            {
+                // second lp withdraws
+                uint256 lp2Balance0Before = key.currency0.balanceOf(address(lp2));
+                uint256 lp2Balance1Before = key.currency1.balanceOf(address(lp2));
+
+                vm.prank(lp2);
+                hook.withdraw(OrderIdLibrary.OrderId.wrap(1), address(lp2));
+
+                uint256 lp2Balance0After = key.currency0.balanceOf(address(lp2));
+                uint256 lp2Balance1After = key.currency1.balanceOf(address(lp2));
+
+                (
+                    ,,,
+                    uint256 currency0TotalAfterLp2Withdraw,
+                    uint256 currency1TotalAfterLp2Withdraw,
+                    uint256 liquidityTotalAfterLp2Withdraw
+                ) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+                assertEq(currency0TotalAfterLp2Withdraw, 0, "currency0Total should be zero");
+                assertEq(currency1TotalAfterLp2Withdraw, 0, "currency1Total should be zero");
+                assertEq(liquidityTotalAfterLp2Withdraw, 0, "liquidityTotal should be 0");
+
+                // lp2 should have received half
+                assertApproxEqAbs(
+                    lp2Balance0After - lp2Balance0Before,
+                    currency0Total / 2,
+                    1,
+                    "lp2 should have received half of the amount0"
+                );
+                assertApproxEqAbs(
+                    lp2Balance1After - lp2Balance1Before,
+                    currency1Total / 2,
+                    1,
+                    "lp2 should have received half of the amount1"
+                );
+            }
+        }
+    }
+}

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -215,8 +215,6 @@ contract LimitOrderHookTest is HookTest {
         (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
 
         assertFalse(filled);
-        assertTrue(currency0 == orderCurrency0);
-        assertTrue(currency1 == orderCurrency1);
         assertEq(currency0Total, 0);
         assertEq(currency1Total, 0);
         assertEq(liquidityTotal, liquidity * 2);
@@ -389,8 +387,6 @@ contract LimitOrderHookTest is HookTest {
         (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
 
         assertFalse(filled, "order should not be filled");
-        assertTrue(currency0 == orderCurrency0);
-        assertTrue(currency1 == orderCurrency1);
         assertEq(currency0Total, 0, "currency0Total should be 0");
         assertEq(currency1Total, 0, "currency1Total should be 0");
         assertEq(liquidityTotal, 2 * liquidity, "liquidityTotal should be 2*liquidity");

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -222,75 +222,6 @@ contract LimitOrderHookTest is HookTest {
         assertEq(hook.getOrderLiquidity(OrderIdLibrary.OrderId.wrap(1), user), liquidity);
     }
 
-    // @TBD: I don't understand this test
-    function test_placeOrder_feesAccrued() public {
-        bool zeroForOne = true;
-        uint128 liquidity = 1000000;
-
-        hook.placeOrder(key, 0, zeroForOne, liquidity);
-
-        // placing the order is the same as adding liquidity to the pool in the range (0, tickSpacing)
-        vm.startPrank(user);
-        hook.placeOrder(key, 0, zeroForOne, liquidity);
-
-        // add liquidity equivalent to two orders
-        modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(2 * liquidity)), 0);
-        vm.stopPrank();
-
-        // this swap should accrue fees to the order, since tick is in range (0, tickSpacing)
-        vm.startPrank(swapper);
-        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
-        swapOnPool(noHookKey, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
-
-        // swap outside of the range (0, tickSpacing) without filling the order to be able to place orders again
-        swapOnPool(noHookKey, true, -1e15, TickMath.getSqrtPriceAtTick(-key.tickSpacing));
-        swapOnPool(key, true, -1e15, TickMath.getSqrtPriceAtTick(-key.tickSpacing));
-
-        vm.stopPrank();
-
-        (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
-
-        assertFalse(filled, "order should not be filled");
-        assertEq(currency0Total, 0, "currency0Total should be 0");
-        assertEq(currency1Total, 0, "currency1Total should be 0");
-        assertEq(liquidityTotal, 2 * liquidity, "liquidityTotal should be 2*liquidity");
-
-        int256 balance0Before = int256(currency0.balanceOf(address(this)));
-        int256 balance1Before = int256(currency1.balanceOf(address(this)));
-        hook.placeOrder(key, 0, zeroForOne, liquidity);
-        int256 balance0AfterPlace = int256(currency0.balanceOf(address(this)));
-        int256 balance1AfterPlace = int256(currency1.balanceOf(address(this)));
-
-        // place the order is the same as add liquidity to the pool in the range (0, tickSpacing)
-
-        vm.startPrank(user);
-        (int128 feesExpected0, int128 feesExpected1) =
-            calculateFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, key.tickSpacing, 0);
-        BalanceDelta delta = modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(liquidity)), 0);
-        vm.stopPrank();
-        (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
-
-        assertFalse(filled, "order should not be filled");
-        assertEq(liquidityTotal, 3 * liquidity, "liquidityTotal should be 3*liquidity");
-
-        assertEq(currency0Total, uint256(uint128(feesExpected0)), "currency0Total should be feesExpected0");
-        assertEq(currency1Total, uint256(uint128(feesExpected1)), "currency1Total should be feesExpected1");
-
-        assertTrue(feesExpected0 > 0 || feesExpected1 > 0, "fees should be accrued");
-
-        // placing the order is the same as adding liquidity, plus the fees accrued to the order (which are in currency total)
-        assertEq(
-            balance0AfterPlace - balance0Before,
-            int256(delta.amount0()) - int256(currency0Total),
-            "fees were not held in currency0Total"
-        );
-        assertEq(
-            balance1AfterPlace - balance1Before,
-            int256(delta.amount1()) - int256(currency1Total),
-            "fees were not held in currency1Total"
-        );
-    }
-
     function test_cancelOrder() public {
         int24 tickLower = 0;
         bool zeroForOne = true;
@@ -428,6 +359,76 @@ contract LimitOrderHookTest is HookTest {
         assertEq(balanceUser1After - balanceUser1Before, int256(delta.amount1()));
     }
 
+    function test_placeOrder_feesAccrued() public {
+        bool zeroForOne = true;
+        uint128 liquidity = 1000000;
+
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+
+        // placing the order is the same as adding liquidity to the pool in the range (0, tickSpacing)
+        vm.startPrank(user);
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+
+        // add liquidity equivalent to two orders
+        modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(2 * liquidity)), 0);
+        vm.stopPrank();
+
+        // this swap should accrue fees to the order, since tick is in range (0, tickSpacing)
+        vm.startPrank(swapper);
+        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+        swapOnPool(noHookKey, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+
+        // swap outside of the range (0, tickSpacing) without filling the order to be able to place orders again
+        swapOnPool(noHookKey, true, -1e15, TickMath.getSqrtPriceAtTick(-key.tickSpacing));
+        swapOnPool(key, true, -1e15, TickMath.getSqrtPriceAtTick(-key.tickSpacing));
+
+        vm.stopPrank();
+
+        (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+
+        assertFalse(filled, "order should not be filled");
+        assertTrue(currency0 == orderCurrency0);
+        assertTrue(currency1 == orderCurrency1);
+        assertEq(currency0Total, 0, "currency0Total should be 0");
+        assertEq(currency1Total, 0, "currency1Total should be 0");
+        assertEq(liquidityTotal, 2 * liquidity, "liquidityTotal should be 2*liquidity");
+
+        int256 balance0Before = int256(currency0.balanceOf(address(this)));
+        int256 balance1Before = int256(currency1.balanceOf(address(this)));
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+        int256 balance0AfterPlace = int256(currency0.balanceOf(address(this)));
+        int256 balance1AfterPlace = int256(currency1.balanceOf(address(this)));
+
+        // place the order is the same as add liquidity to the pool in the range (0, tickSpacing)
+
+        vm.startPrank(user);
+        (int128 feesExpected0, int128 feesExpected1) =
+            calculateFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, key.tickSpacing, 0);
+        BalanceDelta delta = modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(liquidity)), 0);
+        vm.stopPrank();
+        (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+
+        assertFalse(filled, "order should not be filled");
+        assertEq(liquidityTotal, 3 * liquidity, "liquidityTotal should be 3*liquidity");
+
+        assertEq(currency0Total, uint256(uint128(feesExpected0)), "currency0Total should be feesExpected0");
+        assertEq(currency1Total, uint256(uint128(feesExpected1)), "currency1Total should be feesExpected1");
+
+        assertTrue(feesExpected0 > 0 || feesExpected1 > 0, "fees should be accrued");
+
+        // placing the order is the same as adding liquidity, plus the fees accrued to the order (which are in currency total)
+        assertEq(
+            balance0AfterPlace - balance0Before,
+            int256(delta.amount0()) - int256(currency0Total),
+            "fees were not held in currency0Total"
+        );
+        assertEq(
+            balance1AfterPlace - balance1Before,
+            int256(delta.amount1()) - int256(currency1Total),
+            "fees were not held in currency1Total"
+        );
+    }
+
     function test_withdraw_multipleLPs() public {
         int24 tickLower = 0;
         bool zeroForOne = true;
@@ -483,7 +484,6 @@ contract LimitOrderHookTest is HookTest {
         assertEq(currency1Total, 0, "wrong amount of currency1");
     }
 
-    // @TBD: I don't understand this test
     function test_withdraw_feesAccruedFromCancel() public {
         bool zeroForOne = true;
         uint128 liquidity = 1000000;
@@ -554,7 +554,6 @@ contract LimitOrderHookTest is HookTest {
         assertEq(balanceUser1After - balanceUser1Before, int256(delta.amount1()) + int256(initialFeesExpected1));
     }
 
-    // @TBD: I don't understand this test
     function test_withdraw_feesAccruedJIT() public {
         // some user places an order
         hook.placeOrder(key, 0, true, 1e15);

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -215,6 +215,8 @@ contract LimitOrderHookTest is HookTest {
         (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
 
         assertFalse(filled);
+        assertTrue(currency0 == orderCurrency0);
+        assertTrue(currency1 == orderCurrency1);
         assertEq(currency0Total, 0);
         assertEq(currency1Total, 0);
         assertEq(liquidityTotal, liquidity * 2);

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+// External imports
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/src/test/PoolSwapTest.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
-import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {IERC20Minimal} from "@uniswap/v4-core/src/interfaces/external/IERC20Minimal.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {Position} from "@uniswap/v4-core/src/libraries/Position.sol";
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
-import {FullMath} from "@uniswap/v4-core/src/libraries/FullMath.sol";
-import {FixedPoint128} from "@uniswap/v4-core/src/libraries/FixedPoint128.sol";
 import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 // Internal imports
@@ -24,6 +23,7 @@ import {HookTest} from "../utils/HookTest.sol";
 
 contract LimitOrderHookTest is HookTest {
     using StateLibrary for IPoolManager;
+    using SafeCast for *;
 
     LimitOrderHookMock hook;
 
@@ -87,29 +87,6 @@ contract LimitOrderHookTest is HookTest {
         vm.label(Currency.unwrap(currency1), "currency1");
     }
 
-    function calculateExpectedFees(
-        IPoolManager manager,
-        PoolId poolId,
-        address owner,
-        int24 tickLower,
-        int24 tickUpper,
-        bytes32 salt
-    ) internal view returns (int128, int128) {
-        bytes32 positionKey = Position.calculatePositionKey(owner, tickLower, tickUpper, salt);
-        (uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128) =
-            StateLibrary.getPositionInfo(manager, poolId, positionKey);
-
-        (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) =
-            StateLibrary.getFeeGrowthInside(manager, poolId, tickLower, tickUpper);
-
-        uint256 feesExpected0 =
-            FullMath.mulDiv(feeGrowthInside0X128 - feeGrowthInside0LastX128, liquidity, FixedPoint128.Q128);
-        uint256 feesExpected1 =
-            FullMath.mulDiv(feeGrowthInside1X128 - feeGrowthInside1LastX128, liquidity, FixedPoint128.Q128);
-
-        return (int128(int256(feesExpected0)), int128(int256(feesExpected1)));
-    }
-
     function modifyPoolLiquidityNoChecks(
         PoolKey memory poolKey,
         int24 tickLower,
@@ -137,22 +114,16 @@ contract LimitOrderHookTest is HookTest {
         );
     }
 
-    // Helpers
-    function getCurrentTick(PoolId poolId) public view returns (int24 tick) {
-        (uint160 sqrtPriceX96,,,) = manager.getSlot0(poolId);
-        tick = TickMath.getTickAtSqrtPrice(sqrtPriceX96);
-    }
-
     function test_getTickLowerLast() public view {
-        assertEq(hook.getTickLowerLast(key.toId()), 0);
+        assertEq(hook.getTickLowerLast(key.toId()), 0, "tickLowerLast should initially be 0");
     }
 
-    function test_zeroLiquidityRevert() public {
+    function test_placeOrder_zeroLiquidity_reverts() public {
         vm.expectRevert(LimitOrderHook.ZeroLiquidity.selector);
         hook.placeOrder(key, 0, true, 0);
     }
 
-    function test_zeroForOneRightBoundaryOfCurrentRange() public {
+    function test_placeOrder_zeroForOne_rightBoundaryOfCurrentRange() public {
         int24 tickLower = 60;
         bool zeroForOne = true;
         uint128 liquidity = 1000000;
@@ -165,7 +136,7 @@ contract LimitOrderHookTest is HookTest {
         assertEq(manager.getPositionLiquidity(key.toId(), positionId), liquidity);
     }
 
-    function test_zeroForOneLeftBoundaryOfCurrentRange() public {
+    function test_placeOrder_zeroForOne_leftBoundaryOfCurrentRange() public {
         int24 tickLower = 0;
         bool zeroForOne = true;
         uint128 liquidity = 1000000;
@@ -178,25 +149,24 @@ contract LimitOrderHookTest is HookTest {
         assertEq(manager.getPositionLiquidity(key.toId(), positionId), liquidity);
     }
 
-    function test_zeroForOneCrossedRangeRevert() public {
-        vm.expectRevert(LimitOrderHook.CrossedRange.selector);
+    function test_placeOrder_zeroForOne_crossedRangeRevert() public {
+        vm.expectRevert(LimitOrderHook.InvalidRange.selector);
         hook.placeOrder(key, -60, true, 1000000);
     }
 
-    function test_zeroForOneInRangeRevert() public {
-        // swapping is free, there's no liquidity in the pool, so we only need to specify 1 wei
+    function test_placeOrder_zeroForOne_inRangeRevert() public {
+        // since there are no liquidity in the pool, a swap of 1wei is enough to move the tick in range
         swapRouter.swap(
             key,
             SwapParams({zeroForOne: false, amountSpecified: -1 ether, sqrtPriceLimitX96: SQRT_PRICE_1_1 + 1}),
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}),
             bytes("")
         );
-
-        vm.expectRevert(LimitOrderHook.InRange.selector);
+        vm.expectRevert(LimitOrderHook.InvalidRange.selector);
         hook.placeOrder(key, 0, true, 1000000);
     }
 
-    function test_notZeroForOneLeftBoundaryOfCurrentRange() public {
+    function test_placeOrder_oneForZero_leftBoundaryOfCurrentRange() public {
         int24 tickLower = -60;
         bool zeroForOne = false;
         uint128 liquidity = 1000000;
@@ -209,13 +179,13 @@ contract LimitOrderHookTest is HookTest {
         assertEq(manager.getPositionLiquidity(key.toId(), positionId), liquidity);
     }
 
-    function test_notZeroForOneCrossedRangeRevert() public {
-        vm.expectRevert(LimitOrderHook.CrossedRange.selector);
+    function test_placeOrder_oneForZero_crossedRangeRevert() public {
+        vm.expectRevert(LimitOrderHook.InvalidRange.selector);
         hook.placeOrder(key, 0, false, 1000000);
     }
 
-    function test_notZeroForOneInRangeRevert() public {
-        // swapping is free, there's no liquidity in the pool, so we only need to specify 1 wei
+    function test_placeOrder_oneForZero_inRangeRevert() public {
+        // since there are no liquidity in the pool, a swap of 1wei is enough to move the tick in range
         swapRouter.swap(
             key,
             SwapParams({zeroForOne: true, amountSpecified: -1 ether, sqrtPriceLimitX96: SQRT_PRICE_1_1 - 1}),
@@ -223,38 +193,102 @@ contract LimitOrderHookTest is HookTest {
             bytes("")
         );
 
-        vm.expectRevert(LimitOrderHook.InRange.selector);
+        vm.expectRevert(LimitOrderHook.InvalidRange.selector);
         hook.placeOrder(key, -60, false, 1000000);
     }
 
-    function test_multipleLPs() public {
+    function test_placeOrder_multipleLPs() public {
         int24 tickLower = 60;
         bool zeroForOne = true;
         uint128 liquidity = 1000000;
 
         hook.placeOrder(key, tickLower, zeroForOne, liquidity);
 
-        vm.startPrank(user);
+        vm.prank(user);
         hook.placeOrder(key, tickLower, zeroForOne, liquidity);
-        vm.stopPrank();
 
         assertTrue(OrderIdLibrary.equals(hook.getOrderId(key, tickLower, zeroForOne), OrderIdLibrary.OrderId.wrap(1)));
 
         bytes32 positionId = Position.calculatePositionKey(address(hook), tickLower, tickLower + key.tickSpacing, 0);
         assertEq(manager.getPositionLiquidity(key.toId(), positionId), liquidity * 2);
 
-        Currency orderCurrency0;
-        Currency orderCurrency1;
-        (filled, orderCurrency0, orderCurrency1, currency0Total, currency1Total, liquidityTotal) =
-            hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+        (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+
         assertFalse(filled);
-        assertTrue(currency0 == orderCurrency0);
-        assertTrue(currency1 == orderCurrency1);
         assertEq(currency0Total, 0);
         assertEq(currency1Total, 0);
         assertEq(liquidityTotal, liquidity * 2);
         assertEq(hook.getOrderLiquidity(OrderIdLibrary.OrderId.wrap(1), address(this)), liquidity);
         assertEq(hook.getOrderLiquidity(OrderIdLibrary.OrderId.wrap(1), user), liquidity);
+    }
+
+    // @TBD: I don't understand this test
+    function test_placeOrder_feesAccrued() public {
+        bool zeroForOne = true;
+        uint128 liquidity = 1000000;
+
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+
+        // placing the order is the same as adding liquidity to the pool in the range (0, tickSpacing)
+        vm.startPrank(user);
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+
+        // add liquidity equivalent to two orders
+        modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(2 * liquidity)), 0);
+        vm.stopPrank();
+
+        // this swap should accrue fees to the order, since tick is in range (0, tickSpacing)
+        vm.startPrank(swapper);
+        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+        swapOnPool(noHookKey, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+
+        // swap outside of the range (0, tickSpacing) without filling the order to be able to place orders again
+        swapOnPool(noHookKey, true, -1e15, TickMath.getSqrtPriceAtTick(-key.tickSpacing));
+        swapOnPool(key, true, -1e15, TickMath.getSqrtPriceAtTick(-key.tickSpacing));
+
+        vm.stopPrank();
+
+        (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+
+        assertFalse(filled, "order should not be filled");
+        assertEq(currency0Total, 0, "currency0Total should be 0");
+        assertEq(currency1Total, 0, "currency1Total should be 0");
+        assertEq(liquidityTotal, 2 * liquidity, "liquidityTotal should be 2*liquidity");
+
+        int256 balance0Before = int256(currency0.balanceOf(address(this)));
+        int256 balance1Before = int256(currency1.balanceOf(address(this)));
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+        int256 balance0AfterPlace = int256(currency0.balanceOf(address(this)));
+        int256 balance1AfterPlace = int256(currency1.balanceOf(address(this)));
+
+        // place the order is the same as add liquidity to the pool in the range (0, tickSpacing)
+
+        vm.startPrank(user);
+        (int128 feesExpected0, int128 feesExpected1) =
+            calculateFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, key.tickSpacing, 0);
+        BalanceDelta delta = modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(liquidity)), 0);
+        vm.stopPrank();
+        (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+
+        assertFalse(filled, "order should not be filled");
+        assertEq(liquidityTotal, 3 * liquidity, "liquidityTotal should be 3*liquidity");
+
+        assertEq(currency0Total, uint256(uint128(feesExpected0)), "currency0Total should be feesExpected0");
+        assertEq(currency1Total, uint256(uint128(feesExpected1)), "currency1Total should be feesExpected1");
+
+        assertTrue(feesExpected0 > 0 || feesExpected1 > 0, "fees should be accrued");
+
+        // placing the order is the same as adding liquidity, plus the fees accrued to the order (which are in currency total)
+        assertEq(
+            balance0AfterPlace - balance0Before,
+            int256(delta.amount0()) - int256(currency0Total),
+            "fees were not held in currency0Total"
+        );
+        assertEq(
+            balance1AfterPlace - balance1Before,
+            int256(delta.amount1()) - int256(currency1Total),
+            "fees were not held in currency1Total"
+        );
     }
 
     function test_cancelOrder() public {
@@ -277,18 +311,24 @@ contract LimitOrderHookTest is HookTest {
         bool zeroForOne = true;
         uint128 liquidity = 1e15;
 
+        // placing orders is equivalent to adding liquidity to the pool in the range (0, tickSpacing)
+
+        // hooked pool:
+        // `this` user places an order
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+        // `user` user places an order
+        vm.prank(user);
         hook.placeOrder(key, 0, zeroForOne, liquidity);
 
-        //place order is the same as add liquidity to the pool in the range (0, tickSpacing)
-        vm.startPrank(user);
-        hook.placeOrder(key, 0, zeroForOne, liquidity);
+        // unhooked pool:
+        // `this` user adds liquidity equivalent to one order
+        modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(liquidity)), 0);
+        // `user` user adds liquidity equivalent to one order
+        vm.prank(user);
+        modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(liquidity)), 0);
 
-        // add liquidity equivalent to two orders
-        modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(2 * liquidity)), 0);
-        vm.stopPrank();
-
-        // this swap should accrue fees to the order, since tick is in range (0, tickSpacing)
-        vm.startPrank(swapper);
+        // swap should accrue fees to the order, since tick is in range (0, tickSpacing)
+        vm.prank(swapper);
         swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
         swapOnPool(noHookKey, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
         vm.stopPrank();
@@ -300,29 +340,35 @@ contract LimitOrderHookTest is HookTest {
         assertEq(currency1Total, 0, "currency1Total should be 0");
         assertEq(liquidityTotal, 2 * liquidity, "liquidityTotal should be 2*liquidity");
 
+        // canceling the order is equivalent to removing liquidity from the pool in the range (0, tickSpacing)
+
+        // hooked pool:
+        // `user` user cancels the order
         int256 balance0Before = int256(currency0.balanceOf(address(this)));
         int256 balance1Before = int256(currency1.balanceOf(address(this)));
+        vm.prank(user);
         hook.cancelOrder(key, 0, zeroForOne, address(this));
-        int256 balance0AfterCancel = int256(currency0.balanceOf(address(this)));
-        int256 balance1AfterCancel = int256(currency1.balanceOf(address(this)));
+        int256 balance0After = int256(currency0.balanceOf(address(this)));
+        int256 balance1After = int256(currency1.balanceOf(address(this)));
 
-        // cancel the order is the same as remove liquidity from the pool in the range (0, tickSpacing)
-        vm.startPrank(user);
+        // unhooked pool:
+        // `user` user removes liquidity equivalent to the order
+        vm.prank(user);
         (int128 feesExpected0, int128 feesExpected1) =
-            calculateExpectedFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, key.tickSpacing, 0);
-        BalanceDelta delta = modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, -int256(uint256(liquidity)), 0);
-        vm.stopPrank();
+            calculateFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, key.tickSpacing, 0);
 
         (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
 
-        assertEq(currency0Total, uint256(uint128(feesExpected0)));
-        assertEq(currency1Total, uint256(uint128(feesExpected1)));
+        BalanceDelta delta = modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, -int256(uint256(liquidity)), 0);
 
-        assertTrue(feesExpected0 > 0 || feesExpected1 > 0);
+        // The fees accrued in the hooked pool should be accounted in the order `currency1Total` and `currency0Total`,
+        // and the fees should be exactly the same as those in the unhooked pool.
+        assertEq(currency0Total, feesExpected0.toUint256(), "currency0Total should be feesExpected0");
+        assertEq(currency1Total, feesExpected1.toUint256(), "currency1Total should be feesExpected1");
 
         // canceling the order is the same as removing liquidity, minus the fees accrued to the order (which are in currency total)
-        assertEq(balance0AfterCancel - balance0Before, int256(delta.amount0()) - int256(currency0Total));
-        assertEq(balance1AfterCancel - balance1Before, int256(delta.amount1()) - int256(currency1Total));
+        assertEq(balance0After - balance0Before, int256(delta.amount0()) - int256(currency0Total));
+        assertEq(balance1After - balance1Before, int256(delta.amount1()) - int256(currency1Total));
     }
 
     function test_cancelOrder_removingAllLiquidity() public {
@@ -366,83 +412,20 @@ contract LimitOrderHookTest is HookTest {
         // cancel the order is the same as remove liquidity from the pool in the range (0, tickSpacing)
         vm.startPrank(user);
         (int128 feesExpected0, int128 feesExpected1) =
-            calculateExpectedFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, key.tickSpacing, 0);
+            calculateFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, key.tickSpacing, 0);
         BalanceDelta delta = modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, -int256(uint256(liquidity)), 0);
         vm.stopPrank();
 
         assertTrue(feesExpected0 > 0 || feesExpected1 > 0);
 
-        // all fees accrued go to the last user to cancel the order
-        assertEq(balanceUser0After - balanceUser0Before, int256(delta.amount0()) - int256(feesExpected0));
-        assertEq(balanceUser1After - balanceUser1Before, int256(delta.amount1()) - int256(feesExpected1));
-    }
-
-    function test_placeOrder_feesAccrued() public {
-        bool zeroForOne = true;
-        uint128 liquidity = 1000000;
-
-        hook.placeOrder(key, 0, zeroForOne, liquidity);
-
-        //place order is the same as add liquidity to the pool in the range (0, tickSpacing)
-        vm.startPrank(user);
-        hook.placeOrder(key, 0, zeroForOne, liquidity);
-
-        // add liquidity equivalent to two orders
-        modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(2 * liquidity)), 0);
-        vm.stopPrank();
-
-        // this swap should accrue fees to the order, since tick is in range (0, tickSpacing)
-        vm.startPrank(swapper);
-        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
-        swapOnPool(noHookKey, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
-
-        // swap outside of the range (0, tickSpacing) without filling the order to be able to place orders again
-        swapOnPool(noHookKey, true, -1e15, TickMath.getSqrtPriceAtTick(-key.tickSpacing));
-        swapOnPool(key, true, -1e15, TickMath.getSqrtPriceAtTick(-key.tickSpacing));
-
-        vm.stopPrank();
-
-        (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
-
-        assertFalse(filled, "order should not be filled");
-        assertEq(currency0Total, 0, "currency0Total should be 0");
-        assertEq(currency1Total, 0, "currency1Total should be 0");
-        assertEq(liquidityTotal, 2 * liquidity, "liquidityTotal should be 2*liquidity");
-
-        int256 balance0Before = int256(currency0.balanceOf(address(this)));
-        int256 balance1Before = int256(currency1.balanceOf(address(this)));
-        hook.placeOrder(key, 0, zeroForOne, liquidity);
-        int256 balance0AfterPlace = int256(currency0.balanceOf(address(this)));
-        int256 balance1AfterPlace = int256(currency1.balanceOf(address(this)));
-
-        // place the order is the same as add liquidity to the pool in the range (0, tickSpacing)
-
-        vm.startPrank(user);
-        (int128 feesExpected0, int128 feesExpected1) =
-            calculateExpectedFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, key.tickSpacing, 0);
-        BalanceDelta delta = modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(liquidity)), 0);
-        vm.stopPrank();
-        (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
-
-        assertFalse(filled, "order should not be filled");
-        assertEq(liquidityTotal, 3 * liquidity, "liquidityTotal should be 3*liquidity");
-
-        assertEq(currency0Total, uint256(uint128(feesExpected0)), "currency0Total should be feesExpected0");
-        assertEq(currency1Total, uint256(uint128(feesExpected1)), "currency1Total should be feesExpected1");
-
-        assertTrue(feesExpected0 > 0 || feesExpected1 > 0, "fees should be accrued");
-
-        // placing the order is the same as adding liquidity, plus the fees accrued to the order (which are in currency total)
-        assertEq(
-            balance0AfterPlace - balance0Before,
-            int256(delta.amount0()) - int256(currency0Total),
-            "fees were not held in currency0Total"
-        );
-        assertEq(
-            balance1AfterPlace - balance1Before,
-            int256(delta.amount1()) - int256(currency1Total),
-            "fees were not held in currency1Total"
-        );
+        // The last canceller receives their principal PLUS ALL accumulated fees
+        // From the hook: principal (without position fees) + all accumulated fees (minted by earlier cancellers)
+        // From comparison pool: principal + remaining position fees
+        // These should be equal because:
+        //   - Hook principal excludes fees (already minted on first cancel) but adds all accumulated fees
+        //   - Comparison principal includes remaining position fees (not yet collected)
+        assertEq(balanceUser0After - balanceUser0Before, int256(delta.amount0()));
+        assertEq(balanceUser1After - balanceUser1Before, int256(delta.amount1()));
     }
 
     function test_withdraw_multipleLPs() public {
@@ -500,6 +483,7 @@ contract LimitOrderHookTest is HookTest {
         assertEq(currency1Total, 0, "wrong amount of currency1");
     }
 
+    // @TBD: I don't understand this test
     function test_withdraw_feesAccruedFromCancel() public {
         bool zeroForOne = true;
         uint128 liquidity = 1000000;
@@ -525,7 +509,7 @@ contract LimitOrderHookTest is HookTest {
 
         vm.startPrank(user);
         (int128 initialFeesExpected0, int128 initialFeesExpected1) =
-            calculateExpectedFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, key.tickSpacing, 0);
+            calculateFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, key.tickSpacing, 0);
         BalanceDelta delta = modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, -int256(uint256(liquidity)), 0);
         vm.stopPrank();
 
@@ -570,6 +554,7 @@ contract LimitOrderHookTest is HookTest {
         assertEq(balanceUser1After - balanceUser1Before, int256(delta.amount1()) + int256(initialFeesExpected1));
     }
 
+    // @TBD: I don't understand this test
     function test_withdraw_feesAccruedJIT() public {
         // some user places an order
         hook.placeOrder(key, 0, true, 1e15);
@@ -602,7 +587,7 @@ contract LimitOrderHookTest is HookTest {
         // add liquidity to be equivalent as placing the order
         vm.startPrank(user);
         (int128 initialFeesExpected0, int128 initialFeesExpected1) =
-            calculateExpectedFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, tickSpacing, 0);
+            calculateFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, tickSpacing, 0);
         modifyPoolLiquidityNoChecks(noHookKey, 0, tickSpacing, int256(uint256(1e15)), 0);
         vm.stopPrank();
 

--- a/test/utils/HookTest.sol
+++ b/test/utils/HookTest.sol
@@ -17,9 +17,15 @@ import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
 import {IHookEvents} from "src/interfaces/IHookEvents.sol";
 import {IPoolManagerEvents} from "test/utils/interfaces/IPoolManagerEvents.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {LiquidityAmounts} from "@uniswap/v4-core/test/utils/LiquidityAmounts.sol";
 
 // @dev Set of utilities to test Hooks.
 contract HookTest is Test, Deployers, IPoolManagerEvents, IHookEvents {
+    using StateLibrary for IPoolManager;
+    using TickMath for uint160;
+    using LiquidityAmounts for *;
+
     IPoolManager constant POOL_MANAGER = IPoolManager(address(0x000000000004444c5dc75cB358380D2e3dE08A90));
 
     function deployFreshManager() internal override {
@@ -40,6 +46,34 @@ contract HookTest is Test, Deployers, IPoolManagerEvents, IHookEvents {
         modifyLiquidityRouter.modifyLiquidity{value: msg.value}(_key, LIQUIDITY_PARAMS, ZERO_BYTES);
     }
 
+    // @dev Calculate the expected amounts of currency0 and currency1 for a given liquidity and tick range.
+    function calculateAmountsForLiquidity(PoolKey memory key, int24 tickLower, int24 tickUpper, uint128 liquidity)
+        public
+        view
+        returns (uint256 amount0Expected, uint256 amount1Expected)
+    {
+        (uint160 sqrtPriceX96,,,) = manager.getSlot0(key.toId());
+        (amount0Expected, amount1Expected) = LiquidityAmounts.getAmountsForLiquidity(
+            sqrtPriceX96, TickMath.getSqrtPriceAtTick(tickLower), TickMath.getSqrtPriceAtTick(tickUpper), liquidity
+        );
+    }
+
+    // @dev Overload for calculating expected amounts of currency0 and currency1 for a given liquidity and tick.
+    // Note: since the tickUpper is not provided, the expected amounts are for one tick spacing wide range.
+    function calculateAmountsForLiquidity(PoolKey memory key, int24 tickLower, uint128 liquidity)
+        public
+        view
+        returns (uint256 amount0Expected, uint256 amount1Expected)
+    {
+        (uint160 sqrtPriceX96,,,) = manager.getSlot0(key.toId());
+        (amount0Expected, amount1Expected) = LiquidityAmounts.getAmountsForLiquidity(
+            sqrtPriceX96,
+            TickMath.getSqrtPriceAtTick(tickLower),
+            TickMath.getSqrtPriceAtTick(tickLower + key.tickSpacing),
+            liquidity
+        );
+    }
+
     // @dev Calculate the current `feesAccrued` for a given position.
     function calculateFees(
         IPoolManager manager,
@@ -56,8 +90,13 @@ contract HookTest is Test, Deployers, IPoolManagerEvents, IHookEvents {
         (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) =
             StateLibrary.getFeeGrowthInside(manager, poolId, tickLower, tickUpper);
 
-        uint256 fees0 = FullMath.mulDiv(feeGrowthInside0X128 - feeGrowthInside0LastX128, liquidity, FixedPoint128.Q128);
-        uint256 fees1 = FullMath.mulDiv(feeGrowthInside1X128 - feeGrowthInside1LastX128, liquidity, FixedPoint128.Q128);
+        uint256 delta0 =
+            feeGrowthInside0X128 >= feeGrowthInside0LastX128 ? feeGrowthInside0X128 - feeGrowthInside0LastX128 : 0;
+        uint256 delta1 =
+            feeGrowthInside1X128 >= feeGrowthInside1LastX128 ? feeGrowthInside1X128 - feeGrowthInside1LastX128 : 0;
+
+        uint256 fees0 = FullMath.mulDiv(delta0, liquidity, FixedPoint128.Q128);
+        uint256 fees1 = FullMath.mulDiv(delta1, liquidity, FixedPoint128.Q128);
 
         return (int128(int256(fees0)), int128(int256(fees1)));
     }
@@ -87,6 +126,17 @@ contract HookTest is Test, Deployers, IPoolManagerEvents, IHookEvents {
             tickLower: tickLower, tickUpper: tickUpper, liquidityDelta: liquidity, salt: salt
         });
         return modifyLiquidityRouter.modifyLiquidity(poolKey, modifyLiquidityParams, "");
+    }
+
+    // @dev Get the current tick for a given pool.
+    function getCurrentTick(PoolId poolId) public view returns (int24 tick) {
+        (uint160 sqrtPriceX96,,,) = manager.getSlot0(poolId);
+        tick = TickMath.getTickAtSqrtPrice(sqrtPriceX96);
+    }
+
+    // @dev Floored the tick to the nearest multiple of the tick spacing.
+    function flooredTick(int24 tick, int24 tickSpacing) public pure returns (int24) {
+        return (tick / tickSpacing) * tickSpacing;
     }
 
     // @dev Swaps all combinations of `zeroForOne` (true/false) and `amountSpecified` (+,-) in a given pool.


### PR DESCRIPTION
Slightly refactors `LimitOrderHook` to fully support native currency

- Includes fuzzing for the native version in `test/general/LimitOrderHook.native.fuzz.t.sol`
- Performs light variable renamings for clarity and small gas optimizations
- Patches a bug in `cancelOrder` that was preventing from receiving the accumulated fees in the last order removal (removingAllLiquidity == true)

Closes  #116 