### PR TITLE
Fix HookSwap event emission

### DIFF
--- a/src/base/BaseCustomCurve.sol
+++ b/src/base/BaseCustomCurve.sol
@@ -123,26 +123,53 @@ abstract contract BaseCustomCurve is BaseCustomAccounting {
             returnDelta = toBeforeSwapDelta(-specifiedAmount.toInt128(), unspecifiedAmount.toInt128());
         }
 
-        // Emit the swap event with the amounts ordered correctly
-        // NOTE: the fee is paid in the input currency
+        // Emit the swap event with the amounts ordered correctly and signed per the
+        // `IHookEvents.HookSwap` convention (positive for input, negative for output).
+        // NOTE: the fee is paid in the input currency.
         if (specified == key.currency0) {
-            emit HookSwap(
-                PoolId.unwrap(key.toId()),
-                sender,
-                specifiedAmount.toInt128(),
-                unspecifiedAmount.toInt128(),
-                exactInput ? swapFeeAmount.toUint128() : 0, // if specified is currency0 and exactInput = true, the fee is paid in currency0
-                exactInput ? 0 : swapFeeAmount.toUint128() // if specified is currency0 and exactInput = false, the fee is paid in currency1
-            );
+            if (exactInput) {
+                // currency0 is input, currency1 is output
+                emit HookSwap(
+                    PoolId.unwrap(key.toId()),
+                    sender,
+                    specifiedAmount.toInt128(),
+                    -unspecifiedAmount.toInt128(),
+                    swapFeeAmount.toUint128(),
+                    0
+                );
+            } else {
+                // currency0 is output, currency1 is input
+                emit HookSwap(
+                    PoolId.unwrap(key.toId()),
+                    sender,
+                    -specifiedAmount.toInt128(),
+                    unspecifiedAmount.toInt128(),
+                    0,
+                    swapFeeAmount.toUint128()
+                );
+            }
         } else {
-            emit HookSwap(
-                PoolId.unwrap(key.toId()),
-                sender,
-                unspecifiedAmount.toInt128(),
-                specifiedAmount.toInt128(),
-                exactInput ? 0 : swapFeeAmount.toUint128(),
-                exactInput ? swapFeeAmount.toUint128() : 0
-            );
+            if (exactInput) {
+                // currency1 is input, currency0 is output
+                emit HookSwap(
+                    PoolId.unwrap(key.toId()),
+                    sender,
+                    -unspecifiedAmount.toInt128(),
+                    specifiedAmount.toInt128(),
+                    0,
+                    swapFeeAmount.toUint128()
+                );
+            } else {
+                // currency1 is output, currency0 is input
+                emit HookSwap(
+                    PoolId.unwrap(key.toId()),
+                    sender,
+                    unspecifiedAmount.toInt128(),
+                    -specifiedAmount.toInt128(),
+                    swapFeeAmount.toUint128(),
+                    0
+                );
+            }
         }
 
         return (this.beforeSwap.selector, returnDelta, 0);

--- a/test/base/BaseAsyncSwap.t.sol
+++ b/test/base/BaseAsyncSwap.t.sol
@@ -124,6 +124,51 @@ contract BaseAsyncSwapTest is HookTest {
         assertEq(balance0After - balance0Before, 100);
     }
 
+    /// @dev Per `IHookEvents.HookSwap` NatSpec: amount0/amount1 are positive for input, negative for output.
+    /// `BaseAsyncSwap` only acts on exact-input swaps (the input side is taken and the swap is netted to 0,
+    /// so the output side is reported as 0). Exact-output swaps are delegated to the `PoolManager`, so no
+    /// `HookSwap` is emitted. Exercises all 4 (zeroForOne x exactInput) combinations in a single test.
+    function test_hookSwap_event_correctSigns() public {
+        int128 amount = 100;
+
+        for (uint256 i = 0; i < 4; i++) {
+            bool zeroForOne = i < 2;
+            bool exactInput = i % 2 == 0;
+            string memory tag =
+                string.concat("[zeroForOne=", zeroForOne ? "T" : "F", ", exactInput=", exactInput ? "T" : "F", "] ");
+
+            SwapParams memory params = SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: exactInput ? -int256(int128(amount)) : int256(int128(amount)),
+                sqrtPriceLimitX96: zeroForOne ? SQRT_PRICE_1_2 : MAX_PRICE_LIMIT
+            });
+
+            vm.recordLogs();
+            swapRouter.swap(
+                key, params, PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}), ZERO_BYTES
+            );
+            (bytes memory data, bool found) = findLogData(vm.getRecordedLogs(), address(hook), HookSwap.selector);
+
+            if (!exactInput) {
+                assertFalse(found, string.concat(tag, "exact-output must not emit HookSwap"));
+                continue;
+            }
+
+            assertTrue(found, string.concat(tag, "HookSwap should be emitted"));
+            (int128 amount0, int128 amount1,,) = abi.decode(data, (int128, int128, uint128, uint128));
+
+            if (zeroForOne) {
+                // currency0 is input -> positive; currency1 is output -> 0 (async netting)
+                assertEq(amount0, amount, string.concat(tag, "amount0 (input) should equal +specifiedAmount"));
+                assertEq(amount1, int128(0), string.concat(tag, "amount1 (output) is netted to 0"));
+            } else {
+                // currency1 is input -> positive; currency0 is output -> 0 (async netting)
+                assertEq(amount0, int128(0), string.concat(tag, "amount0 (output) is netted to 0"));
+                assertEq(amount1, amount, string.concat(tag, "amount1 (input) should equal +specifiedAmount"));
+            }
+        }
+    }
+
     function test_swap_fuzz_succeeds(bool zeroForOne, int120 amountSpecified) public {
         vm.assume(amountSpecified != 0);
 

--- a/test/base/BaseCustomAccounting.t.sol
+++ b/test/base/BaseCustomAccounting.t.sol
@@ -848,4 +848,36 @@ contract BaseCustomAccountingTest is HookTest {
         vm.expectRevert(BaseCustomAccounting.AlreadyInitialized.selector);
         hook.beforeInitialize(address(this), key, SQRT_PRICE_1_1);
     }
+
+    /// @dev `BaseCustomAccounting` emits the principal delta from the caller's perspective:
+    /// negative when adding (caller pays the pool) and positive when removing (caller receives from the pool).
+    /// Exercises both add and remove for both currencies in a single test, asserting signs and non-zero magnitudes.
+    function test_hookModifyLiquidity_event_correctSigns() public {
+        // Add liquidity -> amounts must be negative (caller pays).
+        vm.recordLogs();
+        hook.addLiquidity(
+            BaseCustomAccounting.AddLiquidityParams(
+                10 ether, 10 ether, 0, 0, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0)
+            )
+        );
+        (bytes memory addData, bool addFound) =
+            findLogData(vm.getRecordedLogs(), address(hook), HookModifyLiquidity.selector);
+        assertTrue(addFound, "HookModifyLiquidity not emitted on add");
+        (int128 addAmount0, int128 addAmount1) = abi.decode(addData, (int128, int128));
+        assertLt(addAmount0, int128(0), "add: amount0 should be negative (caller pays)");
+        assertLt(addAmount1, int128(0), "add: amount1 should be negative (caller pays)");
+
+        // Remove liquidity -> amounts must be positive (caller receives).
+        hook.approve(address(hook), type(uint256).max);
+        vm.recordLogs();
+        hook.removeLiquidity(
+            BaseCustomAccounting.RemoveLiquidityParams(1 ether, 0, 0, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0))
+        );
+        (bytes memory remData, bool remFound) =
+            findLogData(vm.getRecordedLogs(), address(hook), HookModifyLiquidity.selector);
+        assertTrue(remFound, "HookModifyLiquidity not emitted on remove");
+        (int128 remAmount0, int128 remAmount1) = abi.decode(remData, (int128, int128));
+        assertGt(remAmount0, int128(0), "remove: amount0 should be positive (caller receives)");
+        assertGt(remAmount1, int128(0), "remove: amount1 should be positive (caller receives)");
+    }
 }

--- a/test/base/BaseCustomCurve.t.sol
+++ b/test/base/BaseCustomCurve.t.sol
@@ -558,4 +558,78 @@ contract BaseCustomCurveTest is HookTest {
         assertEq(key.currency0.balanceOf(address(this)), prevBalance0 - 0.25 ether);
         assertEq(key.currency1.balanceOf(address(this)), prevBalance1 - 0.25 ether);
     }
+
+    /// @dev Per `IHookEvents.HookSwap` NatSpec: amount0/amount1 are positive for input, negative for output.
+    /// The mock is a constant-sum 1:1 curve, so the absolute values are equal on both sides. Exercises all 4
+    /// (zeroForOne x exactInput) combinations in a single test.
+    function test_hookSwap_event_correctSigns() public {
+        hook.addLiquidity(
+            BaseCustomAccounting.AddLiquidityParams(
+                10 ether, 10 ether, 9 ether, 9 ether, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0)
+            )
+        );
+
+        int128 amount = 0.1 ether;
+
+        for (uint256 i = 0; i < 4; i++) {
+            bool zeroForOne = i < 2;
+            bool exactInput = i % 2 == 0;
+            string memory tag =
+                string.concat("[zeroForOne=", zeroForOne ? "T" : "F", ", exactInput=", exactInput ? "T" : "F", "] ");
+
+            SwapParams memory params = SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: exactInput ? -int256(int128(amount)) : int256(int128(amount)),
+                sqrtPriceLimitX96: zeroForOne ? SQRT_PRICE_1_2 : SQRT_PRICE_2_1
+            });
+
+            vm.recordLogs();
+            swapRouter.swap(
+                key, params, PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}), ZERO_BYTES
+            );
+
+            (bytes memory data, bool found) = findLogData(vm.getRecordedLogs(), address(hook), HookSwap.selector);
+            assertTrue(found, string.concat(tag, "HookSwap not emitted"));
+            (int128 amount0, int128 amount1,,) = abi.decode(data, (int128, int128, uint128, uint128));
+
+            // Constant-sum 1:1 curve: |amount0| == |amount1| == amount.
+            // Input side is always currency`zeroForOne ? 0 : 1`.
+            (int128 expected0, int128 expected1) = zeroForOne ? (amount, -amount) : (-amount, amount);
+            assertEq(amount0, expected0, string.concat(tag, "amount0 sign/magnitude mismatch"));
+            assertEq(amount1, expected1, string.concat(tag, "amount1 sign/magnitude mismatch"));
+        }
+    }
+
+    /// @dev Per the `BaseCustomCurve._modifyLiquidity` flow, the emitted `HookModifyLiquidity` amounts
+    /// are caller-perspective deltas: negative when adding (caller pays the pool) and positive when removing
+    /// (caller receives from the pool). Exercises both add and remove for both currencies in a single test.
+    function test_hookModifyLiquidity_event_correctSigns() public {
+        // Add liquidity -> amounts must be negative (caller pays).
+        vm.recordLogs();
+        hook.addLiquidity(
+            BaseCustomAccounting.AddLiquidityParams(
+                10 ether, 10 ether, 9 ether, 9 ether, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0)
+            )
+        );
+        (bytes memory addData, bool addFound) =
+            findLogData(vm.getRecordedLogs(), address(hook), HookModifyLiquidity.selector);
+        assertTrue(addFound, "HookModifyLiquidity not emitted on add");
+        (int128 addAmount0, int128 addAmount1) = abi.decode(addData, (int128, int128));
+        assertEq(addAmount0, -int128(10 ether), "add: amount0 should equal -addedAmount0");
+        assertEq(addAmount1, -int128(10 ether), "add: amount1 should equal -addedAmount1");
+
+        // Remove liquidity -> amounts must be positive (caller receives).
+        hook.approve(address(hook), type(uint256).max);
+        vm.recordLogs();
+        hook.removeLiquidity(
+            BaseCustomAccounting.RemoveLiquidityParams(2 ether, 0, 0, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0))
+        );
+        (bytes memory remData, bool remFound) =
+            findLogData(vm.getRecordedLogs(), address(hook), HookModifyLiquidity.selector);
+        assertTrue(remFound, "HookModifyLiquidity not emitted on remove");
+        (int128 remAmount0, int128 remAmount1) = abi.decode(remData, (int128, int128));
+        // Mock returns liquidity/2 for each currency, so removing 2 ether -> 1 ether per side.
+        assertEq(remAmount0, int128(1 ether), "remove: amount0 should equal +removedAmount0");
+        assertEq(remAmount1, int128(1 ether), "remove: amount1 should equal +removedAmount1");
+    }
 }

--- a/test/fee/BaseHookFee.t.sol
+++ b/test/fee/BaseHookFee.t.sol
@@ -134,6 +134,42 @@ contract BaseHookFeeTest is HookTest {
         assertEq(hookCurrency1Claims, expectedFee);
     }
 
+    /// @dev `BaseHookFee` emits `HookFee` on the unspecified currency of the swap (the side the hook charges
+    /// the fee on). The fee currency depends on (zeroForOne, exactInput): the unspecified side is `currency1`
+    /// when `zeroForOne == exactInput`, and `currency0` otherwise. Exercises all 4 combinations in a single test.
+    function test_hookFee_event_emittedOnUnspecifiedCurrency() public {
+        int128 amount = 1e10;
+
+        for (uint256 i = 0; i < 4; i++) {
+            bool zeroForOne = i < 2;
+            bool exactInput = i % 2 == 0;
+            string memory tag =
+                string.concat("[zeroForOne=", zeroForOne ? "T" : "F", ", exactInput=", exactInput ? "T" : "F", "] ");
+
+            SwapParams memory params = SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: exactInput ? -int256(int128(amount)) : int256(int128(amount)),
+                sqrtPriceLimitX96: zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT
+            });
+
+            vm.recordLogs();
+            swapRouter.swap(key, params, testSettings, "");
+            (bytes memory data, bool found) = findLogData(vm.getRecordedLogs(), address(hook), HookFee.selector);
+            assertTrue(found, string.concat(tag, "HookFee not emitted"));
+            (uint128 fee0, uint128 fee1) = abi.decode(data, (uint128, uint128));
+
+            // Unspecified currency is currency1 when (exactInput == zeroForOne), else currency0.
+            bool feeOnCurrency1 = exactInput == zeroForOne;
+            if (feeOnCurrency1) {
+                assertEq(fee0, 0, string.concat(tag, "fee0 should be zero"));
+                assertGt(fee1, 0, string.concat(tag, "fee1 should be non-zero"));
+            } else {
+                assertGt(fee0, 0, string.concat(tag, "fee0 should be non-zero"));
+                assertEq(fee1, 0, string.concat(tag, "fee1 should be zero"));
+            }
+        }
+    }
+
     function test_withdrawFees() public {
         SwapParams memory swapParams1 = SwapParams({
             zeroForOne: true,

--- a/test/utils/HookTest.sol
+++ b/test/utils/HookTest.sol
@@ -2,7 +2,7 @@
 // OpenZeppelin Uniswap Hooks (last updated v1.2.0) (test/utils/HookTest.sol)
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
 import {BalanceDelta, toBalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
@@ -93,6 +93,19 @@ contract HookTest is Test, Deployers, IPoolManagerEvents, IHookEvents {
     function swapAllCombinations(PoolKey memory poolKey, uint256 amount) internal {
         for (uint256 i = 0; i < 4; i++) {
             swap(poolKey, i < 2 ? false : true, i % 2 == 0 ? -int256(amount) : int256(amount), ZERO_BYTES);
+        }
+    }
+
+    // @dev Returns the data of the first log in `logs` emitted by `emitter` whose topic0 matches `selector`.
+    function findLogData(Vm.Log[] memory logs, address emitter, bytes32 selector)
+        internal
+        pure
+        returns (bytes memory data, bool found)
+    {
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter == emitter && logs[i].topics.length > 0 && logs[i].topics[0] == selector) {
+                return (logs[i].data, true);
+            }
         }
     }
 


### PR DESCRIPTION
 Fix `HookSwap` output-side sign in `BaseCustomCurve._beforeSwap` (was always  
  positive, violating the `IHookEvents.HookSwap`          
                                                                                
  ## Changes                                  
                                                                                
  - **Fix** `src/base/BaseCustomCurve.sol` — split the emit into 4 explicit
  branches over `(specified == currency0, exactInput)`, each with concrete      
  signed values.
  - Adds tests for all signs and asserts emissions of all events in the `IHookEvents` interface                                                             
  - Generic log lookup `findLogData` lives on `HookTest` for reuse.  