### PR TITLE
Fix Final cancel on LimitOrderHook

### DIFF
--- a/src/base/BaseCustomCurve.sol
+++ b/src/base/BaseCustomCurve.sol
@@ -123,26 +123,53 @@ abstract contract BaseCustomCurve is BaseCustomAccounting {
             returnDelta = toBeforeSwapDelta(-specifiedAmount.toInt128(), unspecifiedAmount.toInt128());
         }
 
-        // Emit the swap event with the amounts ordered correctly
-        // NOTE: the fee is paid in the input currency
+        // Emit the swap event with the amounts ordered correctly and signed per the
+        // `IHookEvents.HookSwap` convention (positive for input, negative for output).
+        // NOTE: the fee is paid in the input currency.
         if (specified == key.currency0) {
-            emit HookSwap(
-                PoolId.unwrap(key.toId()),
-                sender,
-                specifiedAmount.toInt128(),
-                unspecifiedAmount.toInt128(),
-                exactInput ? swapFeeAmount.toUint128() : 0, // if specified is currency0 and exactInput = true, the fee is paid in currency0
-                exactInput ? 0 : swapFeeAmount.toUint128() // if specified is currency0 and exactInput = false, the fee is paid in currency1
-            );
+            if (exactInput) {
+                // currency0 is input, currency1 is output
+                emit HookSwap(
+                    PoolId.unwrap(key.toId()),
+                    sender,
+                    specifiedAmount.toInt128(),
+                    -unspecifiedAmount.toInt128(),
+                    swapFeeAmount.toUint128(),
+                    0
+                );
+            } else {
+                // currency0 is output, currency1 is input
+                emit HookSwap(
+                    PoolId.unwrap(key.toId()),
+                    sender,
+                    -specifiedAmount.toInt128(),
+                    unspecifiedAmount.toInt128(),
+                    0,
+                    swapFeeAmount.toUint128()
+                );
+            }
         } else {
-            emit HookSwap(
-                PoolId.unwrap(key.toId()),
-                sender,
-                unspecifiedAmount.toInt128(),
-                specifiedAmount.toInt128(),
-                exactInput ? 0 : swapFeeAmount.toUint128(),
-                exactInput ? swapFeeAmount.toUint128() : 0
-            );
+            if (exactInput) {
+                // currency1 is input, currency0 is output
+                emit HookSwap(
+                    PoolId.unwrap(key.toId()),
+                    sender,
+                    -unspecifiedAmount.toInt128(),
+                    specifiedAmount.toInt128(),
+                    0,
+                    swapFeeAmount.toUint128()
+                );
+            } else {
+                // currency1 is output, currency0 is input
+                emit HookSwap(
+                    PoolId.unwrap(key.toId()),
+                    sender,
+                    unspecifiedAmount.toInt128(),
+                    -specifiedAmount.toInt128(),
+                    swapFeeAmount.toUint128(),
+                    0
+                );
+            }
         }
 
         return (this.beforeSwap.selector, returnDelta, 0);

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -348,11 +348,10 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
         // snapshot the currency totals before zeroing so the callback can release the hook-held
         // ERC-6909 claims they represent to the final canceller.
-        BalanceDelta currencyTotalSnapshot;
+        BalanceDelta currencyTotalSnapshot =
+            toBalanceDelta(orderInfo.currency0Total.toInt128(), orderInfo.currency1Total.toInt128());
         if (removingAllLiquidity) {
             _setOrderId(key, tickLower, zeroForOne, ORDER_ID_DEFAULT);
-            currencyTotalSnapshot =
-                toBalanceDelta(orderInfo.currency0Total.toInt128(), orderInfo.currency1Total.toInt128());
             orderInfo.currency0Total = 0;
             orderInfo.currency1Total = 0;
         }

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -8,10 +8,11 @@ import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {FullMath} from "@uniswap/v4-core/src/libraries/FullMath.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {SafeCast} from "@uniswap/v4-core/src/libraries/SafeCast.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
-import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {BalanceDelta, toBalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IUnlockCallback} from "@uniswap/v4-core/src/interfaces/callback/IUnlockCallback.sol";
 import {SwapParams, ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
@@ -66,6 +67,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     using StateLibrary for IPoolManager;
     using OrderIdLibrary for OrderIdLibrary.OrderId;
     using CurrencySettler for Currency;
+    using SafeCast for uint256;
 
     /// @dev The info for each order id.
     struct OrderInfo {
@@ -101,13 +103,15 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         uint128 liquidity;
     }
 
-    /// @dev Struct of callback data for the cancel callback.
+    /// @dev Struct of callback data for the cancel callback. `currencyTotalSnapshot` packs the
+    /// pre-zeroing `currency0Total` / `currency1Total` and is only consumed on final cancellation.
     struct CancelCallbackData {
         PoolKey key;
         int24 tickLower;
         int256 liquidityDelta;
         address to;
         bool removingAllLiquidity;
+        BalanceDelta currencyTotalSnapshot;
     }
 
     /// @dev Struct of callback data for the withdraw callback
@@ -342,8 +346,13 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         // subtract the liquidity from the total liquidity
         orderInfo.liquidityTotal -= liquidity;
 
+        // snapshot the currency totals before zeroing so the callback can release the hook-held
+        // ERC-6909 claims they represent to the final canceller.
+        BalanceDelta currencyTotalSnapshot;
         if (removingAllLiquidity) {
             _setOrderId(key, tickLower, zeroForOne, ORDER_ID_DEFAULT);
+            currencyTotalSnapshot =
+                toBalanceDelta(orderInfo.currency0Total.toInt128(), orderInfo.currency1Total.toInt128());
             orderInfo.currency0Total = 0;
             orderInfo.currency1Total = 0;
         }
@@ -353,28 +362,29 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         // by the position, since the limit order is a liquidity addition.
         // Note that `amount0Fee` and `amount1Fee` are the fees accrued by the position and will not be transferred to
         // the `to` address. Instead, they will be added to the order info (benefiting the remaining limit order placers).
+        CancelCallbackData memory cancelData = CancelCallbackData({
+            key: key,
+            tickLower: tickLower,
+            liquidityDelta: -int256(uint256(liquidity)),
+            to: to,
+            removingAllLiquidity: removingAllLiquidity,
+            currencyTotalSnapshot: currencyTotalSnapshot
+        });
         (uint256 amount0Fee, uint256 amount1Fee) = abi.decode(
-            poolManager.unlock(
-                abi.encode(
-                    CallbackData(
-                        CallbackType.Cancel,
-                        abi.encode(
-                            CancelCallbackData(key, tickLower, -int256(uint256(liquidity)), to, removingAllLiquidity)
-                        )
-                    )
-                )
-            ),
+            poolManager.unlock(abi.encode(CallbackData(CallbackType.Cancel, abi.encode(cancelData)))),
             (uint256, uint256)
         );
 
-        // add the fees to the order info
-        // note that the currency totals must be updated after poolManager call as they depend on the returned values of the callback.
-        // This is safe as these functions are only callable on the trusted poolManager
-        unchecked {
-            // slither-disable-next-line reentrancy-no-eth
-            orderInfo.currency0Total += amount0Fee;
-            // slither-disable-next-line reentrancy-no-eth
-            orderInfo.currency1Total += amount1Fee;
+        if (!removingAllLiquidity) {
+            // add the fees to the order info
+            // note that the currency totals must be updated after poolManager call as they depend on the returned values of the callback.
+            // This is safe as these functions are only callable on the trusted poolManager
+            unchecked {
+                // slither-disable-next-line reentrancy-no-eth
+                orderInfo.currency0Total += amount0Fee;
+                // slither-disable-next-line reentrancy-no-eth
+                orderInfo.currency1Total += amount1Fee;
+            }
         }
 
         // emit the cancel event
@@ -523,7 +533,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     /**
      * @dev Internal handler for cancel order callbacks. Takes `cancelData` containing the cancellation details and
      * removes liquidity from the pool. Returns accrued fees `(amount0Fee, amount1Fee)` which are allocated to remaining
-     * limit order placers, or to the cancelling user if they're removing all liquidity.
+     * limit order placers, or, on final cancellation, releases the hook's prior ERC-6909 fee claims to the canceller.
      */
     function _handleCancelCallback(CancelCallbackData memory cancelData)
         internal
@@ -569,9 +579,19 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             // so we need to subtract the fees from the `cancelDelta` to get the principal delta
             principalDelta = cancelDelta - feesAccrued;
         } else {
-            // if the `removingAllLiquidity` flag is true, the fees accrued will be allocated to the placer of the last limit order being cancelled
-            // so we can just use the `cancelDelta` as the principal delta
-            principalDelta = cancelDelta;
+            // burn the hook's prior fee claims so the released amounts can be folded into `principalDelta`
+            // and taken from the pool to the canceller below.
+            BalanceDelta currencyTotalSnapshot = cancelData.currencyTotalSnapshot;
+            int128 currencyTotalSnapshot0 = currencyTotalSnapshot.amount0();
+            int128 currencyTotalSnapshot1 = currencyTotalSnapshot.amount1();
+            if (currencyTotalSnapshot0 > 0) {
+                poolManager.burn(address(this), cancelData.key.currency0.toId(), uint128(currencyTotalSnapshot0));
+            }
+            if (currencyTotalSnapshot1 > 0) {
+                poolManager.burn(address(this), cancelData.key.currency1.toId(), uint128(currencyTotalSnapshot1));
+            }
+
+            principalDelta = cancelDelta + currencyTotalSnapshot;
         }
 
         // if the amount of currency0 is positive, take the currency0 from the pool and send it to the `to` address

--- a/test/base/BaseAsyncSwap.t.sol
+++ b/test/base/BaseAsyncSwap.t.sol
@@ -124,6 +124,51 @@ contract BaseAsyncSwapTest is HookTest {
         assertEq(balance0After - balance0Before, 100);
     }
 
+    /// @dev Per `IHookEvents.HookSwap` NatSpec: amount0/amount1 are positive for input, negative for output.
+    /// `BaseAsyncSwap` only acts on exact-input swaps (the input side is taken and the swap is netted to 0,
+    /// so the output side is reported as 0). Exact-output swaps are delegated to the `PoolManager`, so no
+    /// `HookSwap` is emitted. Exercises all 4 (zeroForOne x exactInput) combinations in a single test.
+    function test_hookSwap_event_correctSigns() public {
+        int128 amount = 100;
+
+        for (uint256 i = 0; i < 4; i++) {
+            bool zeroForOne = i < 2;
+            bool exactInput = i % 2 == 0;
+            string memory tag =
+                string.concat("[zeroForOne=", zeroForOne ? "T" : "F", ", exactInput=", exactInput ? "T" : "F", "] ");
+
+            SwapParams memory params = SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: exactInput ? -int256(int128(amount)) : int256(int128(amount)),
+                sqrtPriceLimitX96: zeroForOne ? SQRT_PRICE_1_2 : MAX_PRICE_LIMIT
+            });
+
+            vm.recordLogs();
+            swapRouter.swap(
+                key, params, PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}), ZERO_BYTES
+            );
+            (bytes memory data, bool found) = findLogData(vm.getRecordedLogs(), address(hook), HookSwap.selector);
+
+            if (!exactInput) {
+                assertFalse(found, string.concat(tag, "exact-output must not emit HookSwap"));
+                continue;
+            }
+
+            assertTrue(found, string.concat(tag, "HookSwap should be emitted"));
+            (int128 amount0, int128 amount1,,) = abi.decode(data, (int128, int128, uint128, uint128));
+
+            if (zeroForOne) {
+                // currency0 is input -> positive; currency1 is output -> 0 (async netting)
+                assertEq(amount0, amount, string.concat(tag, "amount0 (input) should equal +specifiedAmount"));
+                assertEq(amount1, int128(0), string.concat(tag, "amount1 (output) is netted to 0"));
+            } else {
+                // currency1 is input -> positive; currency0 is output -> 0 (async netting)
+                assertEq(amount0, int128(0), string.concat(tag, "amount0 (output) is netted to 0"));
+                assertEq(amount1, amount, string.concat(tag, "amount1 (input) should equal +specifiedAmount"));
+            }
+        }
+    }
+
     function test_swap_fuzz_succeeds(bool zeroForOne, int120 amountSpecified) public {
         vm.assume(amountSpecified != 0);
 

--- a/test/base/BaseCustomAccounting.t.sol
+++ b/test/base/BaseCustomAccounting.t.sol
@@ -848,4 +848,36 @@ contract BaseCustomAccountingTest is HookTest {
         vm.expectRevert(BaseCustomAccounting.AlreadyInitialized.selector);
         hook.beforeInitialize(address(this), key, SQRT_PRICE_1_1);
     }
+
+    /// @dev `BaseCustomAccounting` emits the principal delta from the caller's perspective:
+    /// negative when adding (caller pays the pool) and positive when removing (caller receives from the pool).
+    /// Exercises both add and remove for both currencies in a single test, asserting signs and non-zero magnitudes.
+    function test_hookModifyLiquidity_event_correctSigns() public {
+        // Add liquidity -> amounts must be negative (caller pays).
+        vm.recordLogs();
+        hook.addLiquidity(
+            BaseCustomAccounting.AddLiquidityParams(
+                10 ether, 10 ether, 0, 0, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0)
+            )
+        );
+        (bytes memory addData, bool addFound) =
+            findLogData(vm.getRecordedLogs(), address(hook), HookModifyLiquidity.selector);
+        assertTrue(addFound, "HookModifyLiquidity not emitted on add");
+        (int128 addAmount0, int128 addAmount1) = abi.decode(addData, (int128, int128));
+        assertLt(addAmount0, int128(0), "add: amount0 should be negative (caller pays)");
+        assertLt(addAmount1, int128(0), "add: amount1 should be negative (caller pays)");
+
+        // Remove liquidity -> amounts must be positive (caller receives).
+        hook.approve(address(hook), type(uint256).max);
+        vm.recordLogs();
+        hook.removeLiquidity(
+            BaseCustomAccounting.RemoveLiquidityParams(1 ether, 0, 0, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0))
+        );
+        (bytes memory remData, bool remFound) =
+            findLogData(vm.getRecordedLogs(), address(hook), HookModifyLiquidity.selector);
+        assertTrue(remFound, "HookModifyLiquidity not emitted on remove");
+        (int128 remAmount0, int128 remAmount1) = abi.decode(remData, (int128, int128));
+        assertGt(remAmount0, int128(0), "remove: amount0 should be positive (caller receives)");
+        assertGt(remAmount1, int128(0), "remove: amount1 should be positive (caller receives)");
+    }
 }

--- a/test/base/BaseCustomCurve.t.sol
+++ b/test/base/BaseCustomCurve.t.sol
@@ -558,4 +558,78 @@ contract BaseCustomCurveTest is HookTest {
         assertEq(key.currency0.balanceOf(address(this)), prevBalance0 - 0.25 ether);
         assertEq(key.currency1.balanceOf(address(this)), prevBalance1 - 0.25 ether);
     }
+
+    /// @dev Per `IHookEvents.HookSwap` NatSpec: amount0/amount1 are positive for input, negative for output.
+    /// The mock is a constant-sum 1:1 curve, so the absolute values are equal on both sides. Exercises all 4
+    /// (zeroForOne x exactInput) combinations in a single test.
+    function test_hookSwap_event_correctSigns() public {
+        hook.addLiquidity(
+            BaseCustomAccounting.AddLiquidityParams(
+                10 ether, 10 ether, 9 ether, 9 ether, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0)
+            )
+        );
+
+        int128 amount = 0.1 ether;
+
+        for (uint256 i = 0; i < 4; i++) {
+            bool zeroForOne = i < 2;
+            bool exactInput = i % 2 == 0;
+            string memory tag =
+                string.concat("[zeroForOne=", zeroForOne ? "T" : "F", ", exactInput=", exactInput ? "T" : "F", "] ");
+
+            SwapParams memory params = SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: exactInput ? -int256(int128(amount)) : int256(int128(amount)),
+                sqrtPriceLimitX96: zeroForOne ? SQRT_PRICE_1_2 : SQRT_PRICE_2_1
+            });
+
+            vm.recordLogs();
+            swapRouter.swap(
+                key, params, PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}), ZERO_BYTES
+            );
+
+            (bytes memory data, bool found) = findLogData(vm.getRecordedLogs(), address(hook), HookSwap.selector);
+            assertTrue(found, string.concat(tag, "HookSwap not emitted"));
+            (int128 amount0, int128 amount1,,) = abi.decode(data, (int128, int128, uint128, uint128));
+
+            // Constant-sum 1:1 curve: |amount0| == |amount1| == amount.
+            // Input side is always currency`zeroForOne ? 0 : 1`.
+            (int128 expected0, int128 expected1) = zeroForOne ? (amount, -amount) : (-amount, amount);
+            assertEq(amount0, expected0, string.concat(tag, "amount0 sign/magnitude mismatch"));
+            assertEq(amount1, expected1, string.concat(tag, "amount1 sign/magnitude mismatch"));
+        }
+    }
+
+    /// @dev Per the `BaseCustomCurve._modifyLiquidity` flow, the emitted `HookModifyLiquidity` amounts
+    /// are caller-perspective deltas: negative when adding (caller pays the pool) and positive when removing
+    /// (caller receives from the pool). Exercises both add and remove for both currencies in a single test.
+    function test_hookModifyLiquidity_event_correctSigns() public {
+        // Add liquidity -> amounts must be negative (caller pays).
+        vm.recordLogs();
+        hook.addLiquidity(
+            BaseCustomAccounting.AddLiquidityParams(
+                10 ether, 10 ether, 9 ether, 9 ether, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0)
+            )
+        );
+        (bytes memory addData, bool addFound) =
+            findLogData(vm.getRecordedLogs(), address(hook), HookModifyLiquidity.selector);
+        assertTrue(addFound, "HookModifyLiquidity not emitted on add");
+        (int128 addAmount0, int128 addAmount1) = abi.decode(addData, (int128, int128));
+        assertEq(addAmount0, -int128(10 ether), "add: amount0 should equal -addedAmount0");
+        assertEq(addAmount1, -int128(10 ether), "add: amount1 should equal -addedAmount1");
+
+        // Remove liquidity -> amounts must be positive (caller receives).
+        hook.approve(address(hook), type(uint256).max);
+        vm.recordLogs();
+        hook.removeLiquidity(
+            BaseCustomAccounting.RemoveLiquidityParams(2 ether, 0, 0, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0))
+        );
+        (bytes memory remData, bool remFound) =
+            findLogData(vm.getRecordedLogs(), address(hook), HookModifyLiquidity.selector);
+        assertTrue(remFound, "HookModifyLiquidity not emitted on remove");
+        (int128 remAmount0, int128 remAmount1) = abi.decode(remData, (int128, int128));
+        // Mock returns liquidity/2 for each currency, so removing 2 ether -> 1 ether per side.
+        assertEq(remAmount0, int128(1 ether), "remove: amount0 should equal +removedAmount0");
+        assertEq(remAmount1, int128(1 ether), "remove: amount1 should equal +removedAmount1");
+    }
 }

--- a/test/fee/BaseHookFee.t.sol
+++ b/test/fee/BaseHookFee.t.sol
@@ -134,6 +134,42 @@ contract BaseHookFeeTest is HookTest {
         assertEq(hookCurrency1Claims, expectedFee);
     }
 
+    /// @dev `BaseHookFee` emits `HookFee` on the unspecified currency of the swap (the side the hook charges
+    /// the fee on). The fee currency depends on (zeroForOne, exactInput): the unspecified side is `currency1`
+    /// when `zeroForOne == exactInput`, and `currency0` otherwise. Exercises all 4 combinations in a single test.
+    function test_hookFee_event_emittedOnUnspecifiedCurrency() public {
+        int128 amount = 1e10;
+
+        for (uint256 i = 0; i < 4; i++) {
+            bool zeroForOne = i < 2;
+            bool exactInput = i % 2 == 0;
+            string memory tag =
+                string.concat("[zeroForOne=", zeroForOne ? "T" : "F", ", exactInput=", exactInput ? "T" : "F", "] ");
+
+            SwapParams memory params = SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: exactInput ? -int256(int128(amount)) : int256(int128(amount)),
+                sqrtPriceLimitX96: zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT
+            });
+
+            vm.recordLogs();
+            swapRouter.swap(key, params, testSettings, "");
+            (bytes memory data, bool found) = findLogData(vm.getRecordedLogs(), address(hook), HookFee.selector);
+            assertTrue(found, string.concat(tag, "HookFee not emitted"));
+            (uint128 fee0, uint128 fee1) = abi.decode(data, (uint128, uint128));
+
+            // Unspecified currency is currency1 when (exactInput == zeroForOne), else currency0.
+            bool feeOnCurrency1 = exactInput == zeroForOne;
+            if (feeOnCurrency1) {
+                assertEq(fee0, 0, string.concat(tag, "fee0 should be zero"));
+                assertGt(fee1, 0, string.concat(tag, "fee1 should be non-zero"));
+            } else {
+                assertGt(fee0, 0, string.concat(tag, "fee0 should be non-zero"));
+                assertEq(fee1, 0, string.concat(tag, "fee1 should be zero"));
+            }
+        }
+    }
+
     function test_withdrawFees() public {
         SwapParams memory swapParams1 = SwapParams({
             zeroForOne: true,

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -372,9 +372,10 @@ contract LimitOrderHookTest is HookTest {
 
         assertTrue(feesExpected0 > 0 || feesExpected1 > 0);
 
-        // all fees accrued go to the last user to cancel the order
-        assertEq(balanceUser0After - balanceUser0Before, int256(delta.amount0()) - int256(feesExpected0));
-        assertEq(balanceUser1After - balanceUser1Before, int256(delta.amount1()) - int256(feesExpected1));
+        // all fees accrued go to the last user to cancel the order, so their balance change
+        // equals the full mirror delta (principal + position fees).
+        assertEq(balanceUser0After - balanceUser0Before, int256(delta.amount0()));
+        assertEq(balanceUser1After - balanceUser1Before, int256(delta.amount1()));
     }
 
     function test_placeOrder_feesAccrued() public {
@@ -764,5 +765,317 @@ contract LimitOrderHookTest is HookTest {
 
         vm.expectRevert(LimitOrderHook.NotFilled.selector);
         hook.withdraw(OrderIdLibrary.OrderId.wrap(1), address(this));
+    }
+
+    /// @dev Final cancellation releases the hook's ERC-6909 fee claims accrued by an earlier intermediate cancel.
+    function test_cancelOrder_finalCancel_releasesAccruedFees() public {
+        bool zeroForOne = true;
+        uint128 liquidity = 1e15;
+
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+        vm.prank(user);
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+
+        assertEq(manager.balanceOf(address(hook), currency0.toId()), 0);
+        assertEq(manager.balanceOf(address(hook), currency1.toId()), 0);
+
+        // accrue fees on the 2L position without crossing the order's tick
+        vm.prank(swapper);
+        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+
+        // intermediate cancellation: accrued fees are minted to the hook as ERC-6909 claims
+        hook.cancelOrder(key, 0, zeroForOne, address(this));
+
+        uint256 hookBal0 = manager.balanceOf(address(hook), currency0.toId());
+        uint256 hookBal1 = manager.balanceOf(address(hook), currency1.toId());
+        assertTrue(hookBal0 > 0 || hookBal1 > 0, "fees should accrue to hook on intermediate cancel");
+
+        (,,, uint256 c0Total, uint256 c1Total,) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+        assertEq(c0Total, hookBal0, "currency0Total should match hook claims");
+        assertEq(c1Total, hookBal1, "currency1Total should match hook claims");
+
+        // final cancellation: the hook's claims should be released as part of cancelling the order
+        vm.prank(user);
+        hook.cancelOrder(key, 0, zeroForOne, user);
+
+        assertEq(manager.balanceOf(address(hook), currency0.toId()), 0, "hook retained currency0 claims");
+        assertEq(manager.balanceOf(address(hook), currency1.toId()), 0, "hook retained currency1 claims");
+
+        assertTrue(
+            OrderIdLibrary.equals(hook.getOrderId(key, 0, zeroForOne), OrderIdLibrary.OrderId.wrap(0)),
+            "order id should be reset"
+        );
+        (filled,,, currency0Total, currency1Total, liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+        assertFalse(filled);
+        assertEq(liquidityTotal, 0);
+        assertEq(currency0Total, 0);
+        assertEq(currency1Total, 0);
+    }
+
+    /// @dev Final canceller receives principal + previously accrued fees, matched against the no-hook mirror.
+    function test_cancelOrder_finalCancel_receivesPriorFees() public {
+        bool zeroForOne = true;
+        uint128 liquidity = 1e15;
+
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+
+        vm.startPrank(user);
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+        modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, int256(uint256(2 * liquidity)), 0);
+        vm.stopPrank();
+
+        vm.startPrank(swapper);
+        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+        swapOnPool(noHookKey, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+        vm.stopPrank();
+
+        // intermediate cancel on `key` mints accrued fees to the hook
+        hook.cancelOrder(key, 0, zeroForOne, address(this));
+
+        // capture the position fees on the mirror pool before removing one user's worth.
+        // delta = principal_for_L + position_fees, so it equals what the final canceller should receive.
+        (int128 feesExpected0, int128 feesExpected1) =
+            calculateExpectedFees(manager, noHookKey.toId(), address(modifyLiquidityNoChecks), 0, key.tickSpacing, 0);
+        assertTrue(feesExpected0 > 0 || feesExpected1 > 0, "fees should have accrued");
+
+        vm.prank(user);
+        BalanceDelta delta = modifyPoolLiquidityNoChecks(noHookKey, 0, key.tickSpacing, -int256(uint256(liquidity)), 0);
+
+        int256 balance0Before = int256(currency0.balanceOf(user));
+        int256 balance1Before = int256(currency1.balanceOf(user));
+        vm.prank(user);
+        hook.cancelOrder(key, 0, zeroForOne, user);
+        int256 balance0After = int256(currency0.balanceOf(user));
+        int256 balance1After = int256(currency1.balanceOf(user));
+
+        assertEq(balance0After - balance0Before, int256(delta.amount0()), "currency0 mismatch on final cancel");
+        assertEq(balance1After - balance1Before, int256(delta.amount1()), "currency1 mismatch on final cancel");
+    }
+
+    /// @dev Fee claims accumulated across multiple intermediate cancels are all released to the final canceller.
+    function test_cancelOrder_finalCancel_threeParticipants() public {
+        bool zeroForOne = true;
+        uint128 liquidity = 1e15;
+
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+        vm.prank(user);
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+        vm.prank(attacker);
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+
+        // first batch of fees on the 3L position
+        vm.prank(swapper);
+        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+
+        hook.cancelOrder(key, 0, zeroForOne, address(this));
+
+        uint256 hookBal0AfterFirst = manager.balanceOf(address(hook), currency0.toId());
+        uint256 hookBal1AfterFirst = manager.balanceOf(address(hook), currency1.toId());
+        assertTrue(hookBal0AfterFirst > 0 || hookBal1AfterFirst > 0, "fees should accrue on first cancel");
+
+        // second batch of fees on the 2L position; bring the price back into range first
+        vm.startPrank(swapper);
+        swapOnPool(key, true, -1e20, TickMath.getSqrtPriceAtTick(0));
+        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+        vm.stopPrank();
+
+        vm.prank(user);
+        hook.cancelOrder(key, 0, zeroForOne, user);
+
+        uint256 hookBal0BeforeFinal = manager.balanceOf(address(hook), currency0.toId());
+        uint256 hookBal1BeforeFinal = manager.balanceOf(address(hook), currency1.toId());
+
+        assertTrue(
+            hookBal0BeforeFinal > hookBal0AfterFirst || hookBal1BeforeFinal > hookBal1AfterFirst,
+            "second intermediate cancel should add fees"
+        );
+
+        (,,, uint256 c0TotalBeforeFinal, uint256 c1TotalBeforeFinal,) =
+            hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+        assertEq(c0TotalBeforeFinal, hookBal0BeforeFinal);
+        assertEq(c1TotalBeforeFinal, hookBal1BeforeFinal);
+
+        uint256 cBal0Before = currency0.balanceOf(attacker);
+        uint256 cBal1Before = currency1.balanceOf(attacker);
+        vm.prank(attacker);
+        hook.cancelOrder(key, 0, zeroForOne, attacker);
+
+        assertEq(manager.balanceOf(address(hook), currency0.toId()), 0, "hook retained currency0 claims");
+        assertEq(manager.balanceOf(address(hook), currency1.toId()), 0, "hook retained currency1 claims");
+
+        // final canceller's balance increase covers at least the previously accumulated claims
+        assertGe(
+            currency0.balanceOf(attacker) - cBal0Before,
+            hookBal0BeforeFinal,
+            "final canceller should receive prior currency0 fees"
+        );
+        assertGe(
+            currency1.balanceOf(attacker) - cBal1Before,
+            hookBal1BeforeFinal,
+            "final canceller should receive prior currency1 fees"
+        );
+    }
+
+    /// @dev With a single participant the cancel is also the final cancel; no claims are stranded.
+    function test_cancelOrder_finalCancel_singleParticipant() public {
+        bool zeroForOne = true;
+        uint128 liquidity = 1e15;
+
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+
+        vm.prank(swapper);
+        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+
+        hook.cancelOrder(key, 0, zeroForOne, address(this));
+
+        assertEq(manager.balanceOf(address(hook), currency0.toId()), 0);
+        assertEq(manager.balanceOf(address(hook), currency1.toId()), 0);
+
+        assertTrue(
+            OrderIdLibrary.equals(hook.getOrderId(key, 0, zeroForOne), OrderIdLibrary.OrderId.wrap(0)),
+            "order id should be reset"
+        );
+    }
+
+    /// @dev Fee claims minted to the hook by the place callback (not just by intermediate cancels)
+    /// are also released to the canceller on final cancellation.
+    function test_cancelOrder_finalCancel_releasesPlaceCallbackFees() public {
+        bool zeroForOne = true;
+        uint128 liquidity = 1e15;
+
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+
+        // accrue fees in-range, then push the price below the position so we can re-place without
+        // hitting the in-range check
+        vm.startPrank(swapper);
+        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+        swapOnPool(key, true, -1e20, TickMath.getSqrtPriceAtTick(-key.tickSpacing));
+        vm.stopPrank();
+
+        // re-placement triggers the place callback, which mints the position's accrued fees to the hook
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+
+        uint256 hookBal0 = manager.balanceOf(address(hook), currency0.toId());
+        uint256 hookBal1 = manager.balanceOf(address(hook), currency1.toId());
+        assertTrue(hookBal0 > 0 || hookBal1 > 0, "place callback should mint fee claims to the hook");
+
+        (,,, uint256 c0Total, uint256 c1Total,) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+        assertEq(c0Total, hookBal0, "currency0Total should match hook claims");
+        assertEq(c1Total, hookBal1, "currency1Total should match hook claims");
+
+        // single canceller -> removingAllLiquidity == true. The pre-existing claims must be released.
+        hook.cancelOrder(key, 0, zeroForOne, address(this));
+
+        assertEq(manager.balanceOf(address(hook), currency0.toId()), 0, "hook retained currency0 claims");
+        assertEq(manager.balanceOf(address(hook), currency1.toId()), 0, "hook retained currency1 claims");
+    }
+
+    /// @dev On final cancellation, the principal and the released prior fees go to `to`, not to msg.sender.
+    function test_cancelOrder_finalCancel_separateRecipient() public {
+        bool zeroForOne = true;
+        uint128 liquidity = 1e15;
+
+        address recipient = makeAddr("recipient");
+
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+        vm.prank(user);
+        hook.placeOrder(key, 0, zeroForOne, liquidity);
+
+        vm.prank(swapper);
+        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+
+        hook.cancelOrder(key, 0, zeroForOne, address(this));
+
+        uint256 hookBal0BeforeFinal = manager.balanceOf(address(hook), currency0.toId());
+        uint256 hookBal1BeforeFinal = manager.balanceOf(address(hook), currency1.toId());
+        assertTrue(hookBal0BeforeFinal > 0 || hookBal1BeforeFinal > 0, "intermediate cancel should mint fee claims");
+
+        uint256 senderBal0Before = currency0.balanceOf(user);
+        uint256 senderBal1Before = currency1.balanceOf(user);
+
+        vm.prank(user);
+        hook.cancelOrder(key, 0, zeroForOne, recipient);
+
+        // msg.sender's balance is unchanged
+        assertEq(currency0.balanceOf(user), senderBal0Before, "msg.sender should not receive currency0");
+        assertEq(currency1.balanceOf(user), senderBal1Before, "msg.sender should not receive currency1");
+
+        // recipient receives at least the previously stranded claims plus their principal
+        assertGe(currency0.balanceOf(recipient), hookBal0BeforeFinal, "recipient should receive prior currency0 fees");
+        assertGe(currency1.balanceOf(recipient), hookBal1BeforeFinal, "recipient should receive prior currency1 fees");
+
+        assertEq(manager.balanceOf(address(hook), currency0.toId()), 0);
+        assertEq(manager.balanceOf(address(hook), currency1.toId()), 0);
+    }
+
+    /// @dev Final cancellation of one order must not touch another order's accounting or hook claims.
+    function test_cancelOrder_finalCancel_doesNotAffectOtherOrders() public {
+        uint128 liquidity = 1e15;
+        int24 tickA = 0;
+        int24 tickB = -key.tickSpacing;
+
+        // order A: zeroForOne=true at tick 0, position [0, tickSpacing) - filled when price crosses up through 0
+        // order B: zeroForOne=false at tick -tickSpacing, position [-tickSpacing, 0) - filled when price crosses down through 0
+        // both can be placed at the boundary currentTick=0 without hitting in-range / wrong-side reverts.
+        hook.placeOrder(key, tickA, true, liquidity);
+        vm.prank(user);
+        hook.placeOrder(key, tickA, true, liquidity);
+
+        hook.placeOrder(key, tickB, false, liquidity);
+        vm.prank(user);
+        hook.placeOrder(key, tickB, false, liquidity);
+
+        OrderIdLibrary.OrderId orderAId = hook.getOrderId(key, tickA, true);
+        OrderIdLibrary.OrderId orderBId = hook.getOrderId(key, tickB, false);
+
+        // accrue fees on A by swapping up into [0, tickSpacing); the bucketed tick stays at 0 so no fill triggers
+        vm.prank(swapper);
+        swapOnPool(key, false, -1e20, TickMath.getSqrtPriceAtTick(key.tickSpacing / 2));
+
+        // accrue fees on B by swapping back through 0 into [-tickSpacing, 0); the cross-tick check at tick 0
+        // looks for a zeroForOne=false order at tickLower=0, which doesn't exist - so no fill.
+        vm.prank(swapper);
+        swapOnPool(key, true, -1e20, TickMath.getSqrtPriceAtTick(-key.tickSpacing / 2));
+
+        // intermediate cancels mint each order's fees to the hook independently
+        hook.cancelOrder(key, tickA, true, address(this));
+        hook.cancelOrder(key, tickB, false, address(this));
+
+        (,,, uint256 c0TotalA, uint256 c1TotalA,) = hook.getOrderInfo(orderAId);
+        (,,, uint256 c0TotalB, uint256 c1TotalB,) = hook.getOrderInfo(orderBId);
+
+        // hook's claim balances equal the sum of both orders' currency*Total
+        assertEq(
+            manager.balanceOf(address(hook), currency0.toId()),
+            c0TotalA + c0TotalB,
+            "hook currency0 claims should equal sum"
+        );
+        assertEq(
+            manager.balanceOf(address(hook), currency1.toId()),
+            c1TotalA + c1TotalB,
+            "hook currency1 claims should equal sum"
+        );
+
+        // final cancel of order A
+        vm.prank(user);
+        hook.cancelOrder(key, tickA, true, user);
+
+        // order B's accounting is untouched
+        (,,, uint256 c0TotalBAfter, uint256 c1TotalBAfter, uint128 liquidityTotalB) = hook.getOrderInfo(orderBId);
+        assertEq(c0TotalBAfter, c0TotalB, "order B currency0Total should be unchanged");
+        assertEq(c1TotalBAfter, c1TotalB, "order B currency1Total should be unchanged");
+        assertEq(liquidityTotalB, liquidity, "order B liquidity should be unchanged");
+
+        // hook still holds exactly order B's claims
+        assertEq(
+            manager.balanceOf(address(hook), currency0.toId()),
+            c0TotalB,
+            "hook should still hold order B's currency0 claims"
+        );
+        assertEq(
+            manager.balanceOf(address(hook), currency1.toId()),
+            c1TotalB,
+            "hook should still hold order B's currency1 claims"
+        );
     }
 }

--- a/test/utils/HookTest.sol
+++ b/test/utils/HookTest.sol
@@ -2,7 +2,7 @@
 // OpenZeppelin Uniswap Hooks (last updated v1.2.0) (test/utils/HookTest.sol)
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {Deployers} from "@uniswap/v4-core/test/utils/Deployers.sol";
 import {BalanceDelta, toBalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
@@ -93,6 +93,19 @@ contract HookTest is Test, Deployers, IPoolManagerEvents, IHookEvents {
     function swapAllCombinations(PoolKey memory poolKey, uint256 amount) internal {
         for (uint256 i = 0; i < 4; i++) {
             swap(poolKey, i < 2 ? false : true, i % 2 == 0 ? -int256(amount) : int256(amount), ZERO_BYTES);
+        }
+    }
+
+    // @dev Returns the data of the first log in `logs` emitted by `emitter` whose topic0 matches `selector`.
+    function findLogData(Vm.Log[] memory logs, address emitter, bytes32 selector)
+        internal
+        pure
+        returns (bytes memory data, bool found)
+    {
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter == emitter && logs[i].topics.length > 0 && logs[i].topics[0] == selector) {
+                return (logs[i].data, true);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #127 

  - Snapshot `currency*Total` into a `BalanceDelta` before zeroing and pass it through `CancelCallbackData`.                                                   
  - In `_handleCancelCallback`'s `removingAllLiquidity` branch, burn the snapshot's worth of hook-held ERC-6909 claims and fold them into `principalDelta`, so the canceller receives `principal + prior fees` in one take to `cancelData.to`.                                                            
  - Fix `test_cancelOrder_removingAllLiquidity` (its assertion encoded the bug) and add `test_cancelOrder_finalCancel_*` tests for the basic strand, balance reconciliation, multi-cancel compounding, single canceller, place-callback fee path, separate recipient, and cross-order isolation.
  
  This PR should be merged after #126 