### PR TITLE
LimitOrderHook: guard _fillOrder against filling non-converted positions (#132)

### DIFF
--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -618,6 +618,23 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
         // if the order is not default (not initialized), fill it
         if (!orderId.equals(ORDER_ID_DEFAULT)) {
+            // Defense-in-depth: only fill when the live price confirms the position at
+            // [tickLower, tickLower + tickSpacing] is fully converted into the target currency.
+            // `_getCrossedTicks` may propose a tick whose position is not (fully) converted when
+            // `_tickLowerLasts` is stale (e.g. a subclass performed an internal swap, which Uniswap V4
+            // excludes from the `afterSwap` callback via self-call protection). Filling such an order
+            // would mint and credit the wrong currency and irrecoverably consume the order. If the
+            // position is not fully converted, skip the fill and leave the order active so it can be
+            // filled on a later crossing or cancelled by its placer.
+            (uint160 sqrtPriceX96,,,) = poolManager.getSlot0(key.toId());
+            if (zeroForOne) {
+                // selling currency0 for currency1: fully in currency1 only when price >= upper boundary
+                if (sqrtPriceX96 < TickMath.getSqrtPriceAtTick(tickLower + key.tickSpacing)) return;
+            } else {
+                // selling currency1 for currency0: fully in currency0 only when price <= lower boundary
+                if (sqrtPriceX96 > TickMath.getSqrtPriceAtTick(tickLower)) return;
+            }
+
             // get the order info
             OrderInfo storage orderInfo = _orderInfos[orderId];
 
@@ -698,6 +715,17 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      */
     function getTickLowerLast(PoolId poolId) public view returns (int24) {
         return _tickLowerLasts[poolId];
+    }
+
+    /**
+     * @dev Updates the stored `tickLowerLast` for a `poolId`. Exposed to subclasses so that hooks which
+     * perform internal swaps can keep `_tickLowerLasts` consistent with the live price. Uniswap V4 excludes
+     * a hook's own swaps from the `afterSwap` callback (self-call protection in `Hooks.sol`), so `_afterSwap`
+     * does not run for them and `_tickLowerLasts` would otherwise go stale, causing `_getCrossedTicks` to
+     * compute an incorrect fill window. Subclasses performing internal swaps MUST call this afterwards.
+     */
+    function _setTickLowerLast(PoolId poolId, int24 tickLower) internal {
+        _tickLowerLasts[poolId] = tickLower;
     }
 
     /**

--- a/src/mocks/general/LimitOrderHookMock.sol
+++ b/src/mocks/general/LimitOrderHookMock.sol
@@ -3,12 +3,19 @@ pragma solidity ^0.8.26;
 
 // External imports
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
 // Internal imports
 import {LimitOrderHook} from "../../general/LimitOrderHook.sol";
 import {BaseHook} from "../../base/BaseHook.sol";
 
 contract LimitOrderHookMock is LimitOrderHook {
     constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
+
+    /// @dev Test helper: force a (possibly stale) `tickLowerLast`, mimicking a subclass internal swap
+    /// that Uniswap V4 excludes from `afterSwap` (self-call protection).
+    function setTickLowerLast(PoolId poolId, int24 tickLower) external {
+        _setTickLowerLast(poolId, tickLower);
+    }
 
     // exclude from coverage report
     function test() public {}

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -147,6 +147,53 @@ contract LimitOrderHookTest is HookTest {
         assertEq(hook.getTickLowerLast(key.toId()), 0);
     }
 
+    /**
+     * @dev Reproduces issue #132 (https://github.com/OpenZeppelin/uniswap-hooks/issues/132).
+     *
+     * When `_tickLowerLasts` is stale — as it is left whenever a subclass performs an internal swap,
+     * which Uniswap V4 excludes from the `afterSwap` callback via self-call protection — `_getCrossedTicks`
+     * computes a fill window that no longer matches the live price. `_fillOrder` then fills an order whose
+     * position the price has NOT converted into the target currency: it mints/credits the *deposited*
+     * currency, marks the order `filled`, and resets the order id, permanently consuming the order.
+     *
+     * Without the guard in `_fillOrder` this test fails (the order is filled and `currency1` is credited
+     * to a `oneForZero` order that expected `currency0`). With the guard the fill is skipped and the order
+     * remains active and cancellable.
+     */
+    function test_fillOrder_skipsWhenPositionNotConverted_issue132() public {
+        int24 orderTick = 180; // tickUpper = 240
+        bool zeroForOne = false; // oneForZero order: deposit currency1, expect currency0
+        uint128 liquidity = 1_000_000;
+
+        // 1. Move the price up to ~tick 300 so the oneForZero order at 180 is placeable (position all currency1).
+        swapOnPool(key, false, -1e18, TickMath.getSqrtPriceAtTick(300));
+        assertGe(getCurrentTick(key.toId()), 240);
+
+        // 2. Place the oneForZero order below the current price.
+        hook.placeOrder(key, orderTick, zeroForOne, liquidity);
+
+        // 3. Simulate the stale `_tickLowerLasts` a subclass internal swap leaves behind (reset to init value 0).
+        hook.setTickLowerLast(key.toId(), 0);
+
+        // 4. A DOWN swap landing ABOVE the order's range (tick still > 240). `_getCrossedTicks` uses the stale
+        //    last (0) -> window [0, currentTickLower - spacing] which includes tick 180, so `_afterSwap` calls
+        //    `_fillOrder(key, 180, false)` while the position is still entirely currency1 (not converted).
+        swapOnPool(key, true, -1e18, TickMath.getSqrtPriceAtTick(250));
+        assertGt(getCurrentTick(key.toId()), orderTick + tickSpacing); // price still above the order's range
+
+        // With the guard, the order must NOT be filled, no wrong-token credit, and it stays cancellable.
+        Currency oc0;
+        Currency oc1;
+        (filled, oc0, oc1, currency0Total, currency1Total, liquidityTotal) =
+            hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(1));
+        assertFalse(filled, "order must not be filled while position is not converted");
+        assertEq(currency1Total, 0, "no wrong-token (currency1) should be credited");
+        assertEq(currency0Total, 0, "no currency0 credited either");
+
+        // The placer can still recover the deposited currency1 by cancelling.
+        hook.cancelOrder(key, orderTick, zeroForOne, address(this));
+    }
+
     function test_zeroLiquidityRevert() public {
         vm.expectRevert(LimitOrderHook.ZeroLiquidity.selector);
         hook.placeOrder(key, 0, true, 0);


### PR DESCRIPTION
## Summary
Addresses #132 (irrecoverable wrong-token fill in `LimitOrderHook`) by adding a defense-in-depth guard to `_fillOrder`, plus an `internal _setTickLowerLast` so subclasses that perform internal swaps can keep `_tickLowerLasts` fresh.

## Root cause
`_afterSwap` maintains `_tickLowerLasts`, and `_getCrossedTicks` derives the fill window from it. Uniswap V4's self-call protection in `Hooks.sol` **skips `afterSwap` whenever `msg.sender == address(hook)`**, so any subclass that calls `poolManager.swap()` from inside its own `unlockCallback` (e.g. a `swapAndPlaceOrder` extension) never runs `_afterSwap` and leaves `_tickLowerLasts` stale. A stale `_tickLowerLasts` lets `_getCrossedTicks` return a window that includes an order tick whose position the live price has **not** converted. `_fillOrder` then removes that position, mints the **deposited** currency (not the target), credits it, sets `filled = true` and resets the order id — permanently consuming the order and returning the wrong asset.

The underlying gap: `_fillOrder` trusts the crossed-ticks window unconditionally.

## Fix
1. **Guard in `_fillOrder` (correct regardless of caller / staleness):** read live `slot0` and skip the fill unless the position is fully converted —
   - `zeroForOne` (sell currency0 → currency1): require `sqrtPriceX96 >= getSqrtPriceAtTick(tickLower + tickSpacing)`;
   - `oneForZero` (sell currency1 → currency0): require `sqrtPriceX96 <= getSqrtPriceAtTick(tickLower)`.
   On a skip the order stays active and cancellable, so the worst case degrades from “wrong token, irrecoverable” to “fill deferred”.
2. **`internal _setTickLowerLast(PoolId, int24)`:** lets subclasses performing internal swaps keep `_tickLowerLasts` consistent with live price (addresses the root cause for that pattern) without the brittle storage-layout `sstore` workaround.

## Test
`test_fillOrder_skipsWhenPositionNotConverted_issue132` sets a stale `_tickLowerLasts` (exactly the state a self-swap leaves) and drives `_afterSwap` to attempt a fill of a non-converted `oneForZero` order. Without the guard the test fails (order filled, `currency1` credited to an order that expected `currency0`); with the guard it passes (fill skipped, no miscredit, order cancellable). Full suite stays green (305/305), `forge fmt` clean.

## Notes
- Complementary to #119 (H-01/H-02), which also edits `LimitOrderHook.sol`; happy to rebase onto it.
- The guard prevents the catastrophic miscredit; `_setTickLowerLast` lets subclasses prevent the staleness itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
