### PR TITLE
ReHypothecationHook: add slippage protection to add/remove liquidity (#122)

### DIFF
--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -58,8 +58,9 @@ import {CurrencySettler} from "../utils/CurrencySettler.sol";
  * executed and the posterior payment from the user, preventing swaps from being executed until the PoolManager accumulates enough tokens.
  * Altrough it is very unlikely to happen, it can be mitigated by maintaining some permanent pool liquidity alongside rehypothecated liquidity.
  *
- * WARNING: Liquidity additions and removals may be affected by slippage. Users can protect against unexpected slippage
- * in general by verifying the amount received is as expected, using a wrapper that performs these checks.
+ * WARNING: Liquidity additions and removals may be affected by slippage. Use the slippage-protected overloads of
+ * {addReHypothecatedLiquidity} and {removeReHypothecatedLiquidity}, which take maximum-input / minimum-output bounds,
+ * to protect against unexpected price or yield-source movements between transaction signing and execution.
  *
  * WARNING: This is experimental software and is provided on an "as is" and "as available" basis.
  * We do not give any warranties and will not be liable for any losses incurred through any use of
@@ -91,6 +92,12 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
 
     /// @dev Error thrown when the refund fails.
     error RefundFailed();
+
+    /// @dev Error thrown when the required input amounts exceed the caller-provided maximums (slippage protection).
+    error ExcessiveInput();
+
+    /// @dev Error thrown when the returned output amounts fall below the caller-provided minimums (slippage protection).
+    error InsufficientOutput();
 
     /**
      * @dev Emitted when a `sender` adds rehypothecated `shares` to the `poolKey` pool,
@@ -140,7 +147,16 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * - Sender must have sufficient token balances
      * - Sender must have approved the hook to spend the required tokens
      */
-    function addReHypothecatedLiquidity(uint256 shares)
+    function addReHypothecatedLiquidity(uint256 shares) public payable virtual returns (BalanceDelta delta) {
+        return addReHypothecatedLiquidity(shares, type(uint256).max, type(uint256).max);
+    }
+
+    /**
+     * @dev Slippage-protected variant of {addReHypothecatedLiquidity}. Reverts with {ExcessiveInput} if the required
+     * `amount0` or `amount1` (see {previewMint}) exceeds `amount0Max` or `amount1Max` respectively, protecting against
+     * sandwiching and price/yield-source movements between transaction signing and execution.
+     */
+    function addReHypothecatedLiquidity(uint256 shares, uint256 amount0Max, uint256 amount1Max)
         public
         payable
         virtual
@@ -151,6 +167,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         if (shares == 0) revert ZeroShares();
 
         (uint256 amount0, uint256 amount1) = previewMint(shares);
+        if (amount0 > amount0Max || amount1 > amount1Max) revert ExcessiveInput();
 
         _transferFromSenderToHook(_poolKey.currency0, amount0, msg.sender);
         _transferFromSenderToHook(_poolKey.currency1, amount1, msg.sender);
@@ -178,11 +195,26 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * - Pool must be initialized
      * - Sender must have sufficient shares for the desired liquidity withdrawal
      */
-    function removeReHypothecatedLiquidity(uint256 shares) public virtual nonReentrant returns (BalanceDelta delta) {
+    function removeReHypothecatedLiquidity(uint256 shares) public virtual returns (BalanceDelta delta) {
+        return removeReHypothecatedLiquidity(shares, 0, 0);
+    }
+
+    /**
+     * @dev Slippage-protected variant of {removeReHypothecatedLiquidity}. Reverts with {InsufficientOutput} if the
+     * returned `amount0` or `amount1` (see {previewRedeem}) is below `amount0Min` or `amount1Min` respectively,
+     * protecting against sandwiching and price/yield-source movements between transaction signing and execution.
+     */
+    function removeReHypothecatedLiquidity(uint256 shares, uint256 amount0Min, uint256 amount1Min)
+        public
+        virtual
+        nonReentrant
+        returns (BalanceDelta delta)
+    {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
         if (shares == 0) revert ZeroShares();
 
         (uint256 amount0, uint256 amount1) = previewRedeem(shares);
+        if (amount0 < amount0Min || amount1 < amount1Min) revert InsufficientOutput();
 
         _burn(msg.sender, shares);
 

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -145,6 +145,62 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         hook.addReHypothecatedLiquidity(0);
     }
 
+    // --- Slippage protection (issue #122) ---
+
+    function test_add_slippage_revertsOnExcessiveInput() public {
+        uint256 shares = 1e15;
+        (uint256 amount0, uint256 amount1) = hook.previewMint(shares);
+        assertGt(amount0, 0);
+        assertGt(amount1, 0);
+
+        // amount0Max below the required amount0 reverts
+        vm.expectRevert(ReHypothecationHook.ExcessiveInput.selector);
+        hook.addReHypothecatedLiquidity(shares, amount0 - 1, amount1);
+
+        // amount1Max below the required amount1 reverts
+        vm.expectRevert(ReHypothecationHook.ExcessiveInput.selector);
+        hook.addReHypothecatedLiquidity(shares, amount0, amount1 - 1);
+    }
+
+    function test_add_slippage_succeedsWithinBounds() public {
+        uint256 shares = 1e15;
+        (uint256 amount0, uint256 amount1) = hook.previewMint(shares);
+
+        // exact bounds pull exactly the previewed amounts and mint the shares
+        BalanceDelta delta = hook.addReHypothecatedLiquidity(shares, amount0, amount1);
+        assertEq((-delta.amount0()).toUint256(), amount0);
+        assertEq((-delta.amount1()).toUint256(), amount1);
+        assertEq(hook.balanceOf(address(this)), shares);
+
+        // the no-bounds overload remains usable (backwards compatible)
+        hook.addReHypothecatedLiquidity(shares);
+        assertEq(hook.balanceOf(address(this)), shares * 2);
+    }
+
+    function test_remove_slippage_revertsOnInsufficientOutput() public {
+        uint256 shares = 1e15;
+        hook.addReHypothecatedLiquidity(shares);
+        (uint256 amount0, uint256 amount1) = hook.previewRedeem(shares);
+
+        // requiring more than will be returned reverts
+        vm.expectRevert(ReHypothecationHook.InsufficientOutput.selector);
+        hook.removeReHypothecatedLiquidity(shares, amount0 + 1, amount1);
+
+        vm.expectRevert(ReHypothecationHook.InsufficientOutput.selector);
+        hook.removeReHypothecatedLiquidity(shares, amount0, amount1 + 1);
+    }
+
+    function test_remove_slippage_succeedsWithinBounds() public {
+        uint256 shares = 1e15;
+        hook.addReHypothecatedLiquidity(shares);
+        (uint256 amount0, uint256 amount1) = hook.previewRedeem(shares);
+
+        BalanceDelta delta = hook.removeReHypothecatedLiquidity(shares, amount0, amount1);
+        assertEq(delta.amount0().toUint256(), amount0);
+        assertEq(delta.amount1().toUint256(), amount1);
+        assertEq(hook.balanceOf(address(this)), 0);
+    }
+
     function testFuzz_add_singleLP(uint128 shares) public {
         shares = uint128(bound(shares, 1e12, 1e20));
 


### PR DESCRIPTION
## Summary
Addresses #122. `addReHypothecatedLiquidity` and `removeReHypothecatedLiquidity` accepted only `shares` and derived the actual token amounts from the live pool price (when `totalSupply() == 0`) or from yield-source balances, with no slippage bounds — exposing users to sandwiching and price/yield movement between transaction signing and execution.

## Changes
- `addReHypothecatedLiquidity(shares, amount0Max, amount1Max)` — reverts with `ExcessiveInput` if the required input (see `previewMint`) exceeds the caller's maximums.
- `removeReHypothecatedLiquidity(shares, amount0Min, amount1Min)` — reverts with `InsufficientOutput` if the returned output (see `previewRedeem`) is below the caller's minimums.
- The original single-argument functions are preserved and delegate to the new overloads with unbounded limits, so existing integrations are unaffected (opt-in protection).
- Updated the slippage `WARNING` in the contract docstring to point at the new overloads.

## Design note
The change is intentionally backwards-compatible (the 1-arg functions remain, unbounded). If you'd prefer to make the bounds mandatory (dropping the unbounded path) or a different parameter naming/convention, happy to adjust.

## Tests
Four new tests in `ReHypothecationHookERC4626.t.sol`: revert on excessive input, revert on insufficient output, success within bounds, and backwards-compatibility of the single-argument overload. Full suite green (308/308), `forge fmt` clean.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)
