### PR TITLE
LiquidityPenaltyHook: configure blockNumberOffset via overridable getter (#75)

### DIFF
--- a/src/general/LiquidityPenaltyHook.sol
+++ b/src/general/LiquidityPenaltyHook.sol
@@ -63,16 +63,9 @@ abstract contract LiquidityPenaltyHook is BaseHook {
     error NoLiquidityToReceiveDonation();
 
     /**
-     * @dev The minimum value for the {blockNumberOffset}.
+     * @dev The minimum value for the {getBlockNumberOffset}.
      */
     uint48 public constant MIN_BLOCK_NUMBER_OFFSET = 1;
-
-    /**
-     * @dev The minimum time window (in blocks) that must pass after adding liquidity before it can be
-     * removed without any penalty. During this period, JIT attacks are deterred through fee withholding
-     * and penalties. Higher values provide stronger JIT protection but may discourage legitimate LPs.
-     */
-    uint48 public immutable blockNumberOffset;
 
     /**
      * @dev Tracks the `lastAddedLiquidityBlock` for a liquidity position.
@@ -83,14 +76,6 @@ abstract contract LiquidityPenaltyHook is BaseHook {
      * @dev Tracks the `withheldFees` for a liquidity position.
      */
     mapping(PoolId poolId => mapping(bytes32 positionKey => BalanceDelta delta)) private _withheldFees;
-
-    /**
-     * @dev Sets the {getBlockNumberOffset} and the {poolManager} address.
-     */
-    constructor(uint48 _blockNumberOffset) {
-        if (_blockNumberOffset < MIN_BLOCK_NUMBER_OFFSET) revert BlockNumberOffsetTooLow();
-        blockNumberOffset = _blockNumberOffset;
-    }
 
     /**
      * @dev Tracks `lastAddedLiquidityBlock` and withholds `feeDelta` if liquidity was recently added within
@@ -110,7 +95,7 @@ abstract contract LiquidityPenaltyHook is BaseHook {
         bytes32 positionKey = Position.calculatePositionKey(sender, params.tickLower, params.tickUpper, params.salt);
 
         // If liquidity was added recently within the `blockNumberOffset`, retain the feeDelta in this hook.
-        if (_getBlockNumber() - getLastAddedLiquidityBlock(poolId, positionKey) < blockNumberOffset) {
+        if (_getBlockNumber() - getLastAddedLiquidityBlock(poolId, positionKey) < getBlockNumberOffset()) {
             _updateLastAddedLiquidityBlock(poolId, positionKey);
             _takeFeesToHook(key, positionKey, feeDelta);
 
@@ -155,7 +140,7 @@ abstract contract LiquidityPenaltyHook is BaseHook {
         uint48 lastAddedLiquidityBlock = getLastAddedLiquidityBlock(poolId, positionKey);
 
         if (
-            _getBlockNumber() - lastAddedLiquidityBlock < blockNumberOffset
+            _getBlockNumber() - lastAddedLiquidityBlock < getBlockNumberOffset()
                 && totalFees != BalanceDeltaLibrary.ZERO_DELTA
         ) {
             BalanceDelta liquidityPenalty = _calculateLiquidityPenalty(totalFees, lastAddedLiquidityBlock);
@@ -185,6 +170,19 @@ abstract contract LiquidityPenaltyHook is BaseHook {
      */
     function _getBlockNumber() internal view virtual returns (uint48) {
         return uint48(block.number);
+    }
+
+    /**
+     * @dev The minimum time window (in blocks) that must pass after adding liquidity before it can be
+     * removed without any penalty. During this period, JIT attacks are deterred through fee withholding
+     * and penalties. Higher values provide stronger JIT protection but may discourage legitimate LPs.
+     *
+     * Defaults to 16 blocks. Override to customize the offset for a specific deployment instead of configuring
+     * it through the constructor. The returned value MUST be `>= MIN_BLOCK_NUMBER_OFFSET`: it is used as the
+     * divisor in {_calculateLiquidityPenalty}, so a value of `0` would cause a division by zero.
+     */
+    function getBlockNumberOffset() public view virtual returns (uint48) {
+        return 16;
     }
 
     /**
@@ -249,6 +247,7 @@ abstract contract LiquidityPenaltyHook is BaseHook {
         returns (BalanceDelta liquidityPenalty)
     {
         uint48 currentBlockNumber = _getBlockNumber();
+        uint48 blockNumberOffset = getBlockNumberOffset();
 
         unchecked {
             uint256 amount0LiquidityPenalty = FullMath.mulDiv(

--- a/src/mocks/general/LiquidityPenaltyHookMock.sol
+++ b/src/mocks/general/LiquidityPenaltyHookMock.sol
@@ -8,10 +8,17 @@ import {LiquidityPenaltyHook} from "../../general/LiquidityPenaltyHook.sol";
 import {BaseHook} from "../../base/BaseHook.sol";
 
 contract LiquidityPenaltyHookMock is LiquidityPenaltyHook {
-    constructor(IPoolManager _poolManager, uint48 _blockNumberOffset)
-        LiquidityPenaltyHook(_blockNumberOffset)
-        BaseHook(_poolManager)
-    {}
+    uint48 private immutable _blockNumberOffset;
+
+    constructor(IPoolManager _poolManager, uint48 blockNumberOffset_) BaseHook(_poolManager) {
+        if (blockNumberOffset_ < MIN_BLOCK_NUMBER_OFFSET) revert BlockNumberOffsetTooLow();
+        _blockNumberOffset = blockNumberOffset_;
+    }
+
+    /// @dev Overrides the default offset with the constructor-provided value (configurable for tests).
+    function getBlockNumberOffset() public view override returns (uint48) {
+        return _blockNumberOffset;
+    }
 
     // exclude from coverage report
     function test() public {}

--- a/test/general/LiquidityPenaltyHook.t.sol
+++ b/test/general/LiquidityPenaltyHook.t.sol
@@ -70,6 +70,12 @@ contract LiquidityPenaltyHookTest is HookTest, BalanceDeltaAssertions {
         );
     }
 
+    function test_getBlockNumberOffset_returnsConfiguredValue() public view {
+        // issue #75: the offset is now configured by overriding the virtual `getBlockNumberOffset()` getter
+        // (the mock returns its constructor-provided value, set to 1 in setUp) rather than via the base constructor.
+        assertEq(hook.getBlockNumberOffset(), 1);
+    }
+
     function test_noSwaps() public {
         // add liquidity
         modifyPoolLiquidity(key, TICK_LOWER, TICK_UPPER, LIQUIDITY_AMOUNT_1E18, 0);


### PR DESCRIPTION
## Summary
Implements #75: replace the constructor-set `immutable blockNumberOffset` with a virtual `getBlockNumberOffset()` that returns a default of **16** blocks, so subclasses customize the offset by overriding the getter instead of being forced to choose a value at construction (per @ernestognw's suggestion in the [linked review on #67](https://github.com/OpenZeppelin/uniswap-hooks/pull/67#discussion_r2136828655)).

## Changes
- **`LiquidityPenaltyHook`**: remove the `blockNumberOffset` immutable and the constructor; add `getBlockNumberOffset() public view virtual returns (uint48)` defaulting to `16`, and route the existing usages through it. The getter name matches the contract's existing `{getBlockNumberOffset}` NatSpec references. `MIN_BLOCK_NUMBER_OFFSET` is kept and documented as the floor that overrides must respect (it is the divisor in `_calculateLiquidityPenalty`, so `0` would revert).
- **`LiquidityPenaltyHookMock`**: keep the offset configurable for tests by storing it in an immutable, validating `>= MIN_BLOCK_NUMBER_OFFSET`, and overriding `getBlockNumberOffset()`.

## Notes
- Scoped to the override mechanism. The issue also mentions "calculating/testing/recommending a default value"; I used `16` as floated in the review and left any deeper value analysis out to keep this focused — happy to follow up separately.
- Behavior is unchanged: full suite green (304 tests), including the existing deploy-with-low-offset revert and the offset fuzz tests; added a small test asserting the new getter returns the configured value.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
