### PR TITLE
Guard zero-amount claim redemptions in LimitOrderHook

### DIFF
--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -673,10 +673,11 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     }
 
     /**
-     * @dev Sends `amount` of `currency` to `to`, redeeming the claims the hook holds for it.
+     * @dev Sends `amount` of `currency` to `to`, redeeming the claims the hook holds for it. Returns early when
+     * `amount` is zero, since the transfer it would otherwise make reverts for tokens that reject zero-value
+     * transfers, and for recipients that cannot receive the native currency.
      */
     function _sendFromClaims(Currency currency, address to, uint256 amount) private {
-        // skip zero-amount redemptions because some tokens revert on zero-value transfers
         if (amount == 0) return;
 
         // burn the claims the hook holds for the currency

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -676,6 +676,9 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      * @dev Sends `amount` of `currency` to `to`, redeeming the claims the hook holds for it.
      */
     function _sendFromClaims(Currency currency, address to, uint256 amount) private {
+        // skip zero-amount redemptions because some tokens revert on zero-value transfers
+        if (amount == 0) return;
+
         // burn the claims the hook holds for the currency
         poolManager.burn(address(this), currency.toId(), amount);
         // take the currency from the pool and send it to the `to` address

--- a/src/mocks/general/ERC20RejectZeroTransferMock.sol
+++ b/src/mocks/general/ERC20RejectZeroTransferMock.sol
@@ -4,10 +4,13 @@ pragma solidity ^0.8.26;
 // External imports
 import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 
+/// @title ERC20RejectZeroTransferMock
+/// @notice A mock ERC-20 that rejects zero-value transfers, as some tokens do.
 contract ERC20RejectZeroTransferMock is ERC20Mock {
     /// @dev A zero-value transfer was attempted.
     error ZeroTransfer();
 
+    /// @dev Reverts on a zero-value transfer. Mints and burns are left unaffected.
     function _update(address from, address to, uint256 value) internal virtual override {
         if (value == 0 && from != address(0) && to != address(0)) revert ZeroTransfer();
         super._update(from, to, value);

--- a/src/mocks/general/ERC20RejectZeroTransferMock.sol
+++ b/src/mocks/general/ERC20RejectZeroTransferMock.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+// External imports
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+
+contract ERC20RejectZeroTransferMock is ERC20Mock {
+    /// @dev A zero-value transfer was attempted.
+    error ZeroTransfer();
+
+    function _update(address from, address to, uint256 value) internal virtual override {
+        if (value == 0 && from != address(0) && to != address(0)) revert ZeroTransfer();
+        super._update(from, to, value);
+    }
+
+    // Exclude from coverage report
+    function test() public {}
+}

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -19,6 +19,7 @@ import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {BaseHook} from "src/base/BaseHook.sol";
 import {LimitOrderHook, OrderIdLibrary} from "src/general/LimitOrderHook.sol";
 import {LimitOrderHookMock} from "../../src/mocks/general/LimitOrderHookMock.sol";
+import {ERC20RejectZeroTransferMock} from "../../src/mocks/general/ERC20RejectZeroTransferMock.sol";
 import {HookTest} from "../utils/HookTest.sol";
 
 contract LimitOrderHookTest is HookTest {
@@ -178,6 +179,24 @@ contract LimitOrderHookTest is HookTest {
         swapToLimit(key, true, -1e18, -tickSpacing / 2);
         swapToLimit(noHookKey, true, -1e18, -tickSpacing / 2);
         vm.stopPrank();
+    }
+
+    function initRejectZeroTransferPool()
+        internal
+        returns (PoolKey memory poolKey, ERC20RejectZeroTransferMock token, bool tokenIsCurrency0)
+    {
+        token = new ERC20RejectZeroTransferMock();
+        Currency rejectingCurrency = Currency.wrap(address(token));
+
+        if (uint160(address(token)) < uint160(Currency.unwrap(currency0))) {
+            (poolKey,) = initPool(rejectingCurrency, currency0, IHooks(address(hook)), 3000, SQRT_PRICE_1_1);
+            tokenIsCurrency0 = true;
+        } else {
+            (poolKey,) = initPool(currency0, rejectingCurrency, IHooks(address(hook)), 3000, SQRT_PRICE_1_1);
+        }
+
+        token.mint(address(this), 1e30);
+        token.approve(address(hook), type(uint256).max);
     }
 
     // ------------------------------------- Place ------------------------------------- //
@@ -458,6 +477,31 @@ contract LimitOrderHookTest is HookTest {
         hook.cancelOrder(key, 0, true, address(this));
     }
 
+    function test_cancelOrder_tokenRevertingOnZeroTransfer() public {
+        (PoolKey memory poolKey, ERC20RejectZeroTransferMock token, bool tokenIsCurrency0) =
+            initRejectZeroTransferPool();
+        int24 tickLower = tokenIsCurrency0 ? int24(0) : -poolKey.tickSpacing;
+        uint128 liquidity = 1e15;
+        uint256 balanceBefore = token.balanceOf(address(this));
+
+        hook.placeOrder(poolKey, tickLower, tokenIsCurrency0, liquidity);
+        assertLt(token.balanceOf(address(this)), balanceBefore, "placing should spend the rejecting token");
+
+        (uint256 owed0, uint256 owed1) = feesOwedTo(1, address(this));
+        assertEq(owed0, 0, "canceller should be owed no currency0 fees");
+        assertEq(owed1, 0, "canceller should be owed no currency1 fees");
+        (int128 pending0, int128 pending1) =
+            calculateFees(manager, poolKey.toId(), address(hook), tickLower, tickLower + poolKey.tickSpacing, 0);
+        assertEq(pending0, 0, "position should have no pending currency0 fees");
+        assertEq(pending1, 0, "position should have no pending currency1 fees");
+
+        hook.cancelOrder(poolKey, tickLower, tokenIsCurrency0, address(this));
+
+        assertApproxEqAbs(
+            token.balanceOf(address(this)), balanceBefore, DUST, "cancel should return the rejecting token principal"
+        );
+    }
+
     function test_cancelOrder_afterFullCancel_newOrderId() public {
         hook.placeOrder(key, 0, true, 1000000);
         hook.cancelOrder(key, 0, true, address(this));
@@ -705,6 +749,21 @@ contract LimitOrderHookTest is HookTest {
         vm.prank(user);
         vm.expectRevert(LimitOrderHook.ZeroLiquidity.selector);
         hook.withdraw(OrderIdLibrary.OrderId.wrap(1), user);
+    }
+
+    function test_withdraw_tokenRevertingOnZeroTransfer() public {
+        (PoolKey memory poolKey,, bool tokenIsCurrency0) = initRejectZeroTransferPool();
+        int24 tickLower = tokenIsCurrency0 ? int24(0) : -poolKey.tickSpacing;
+        bool zeroForOne = tokenIsCurrency0;
+
+        hook.placeOrder(poolKey, tickLower, zeroForOne, 1e15);
+        vm.prank(swapper);
+        swapToLimit(poolKey, !zeroForOne, -1e18, zeroForOne ? 2 * poolKey.tickSpacing : -2 * poolKey.tickSpacing);
+
+        (uint256 amount0, uint256 amount1) = hook.withdraw(OrderIdLibrary.OrderId.wrap(1), address(this));
+
+        assertEq(tokenIsCurrency0 ? amount0 : amount1, 0, "withdraw should owe no rejecting token");
+        assertGt(tokenIsCurrency0 ? amount1 : amount0, 0, "withdraw should pay the filled principal");
     }
 
     function test_withdraw_singleOwner() public {


### PR DESCRIPTION
Fixes #147

Tbh this is my first time writing Solidity outside of coursework, so Id appreciate some extra scrutiny on this PR („• ֊ •„)

## Summary

Skips zero-amount redemptions in `LimitOrderHook._sendFromClaims` to avoid zero-value ERC-20 transfers, which may revert for some tokens.

Adds a reverting ERC-20 mock and regression tests covering both `cancelOrder` and `withdraw`.

### Tests

- `npm run lint`
- `forge test -v`
- `forge coverage --match-contract LimitOrderHookTest --report summary`
