### PR TITLE
LimitOrderHook: validate the pool, read the stored tick, salt positions by direction

### DIFF
--- a/src/base/BaseHook.sol
+++ b/src/base/BaseHook.sol
@@ -44,6 +44,11 @@ abstract contract BaseHook is IHooks {
     error NotPoolManager();
 
     /**
+     * @dev The pool is not configured to use this hook.
+     */
+    error InvalidPool();
+
+    /**
      * @dev Check that the hook address matches the expected permissions and flags.
      */
     constructor(IPoolManager _poolManager) {
@@ -56,6 +61,17 @@ abstract contract BaseHook is IHooks {
      */
     modifier onlyPoolManager() {
         if (msg.sender != address(poolManager)) revert NotPoolManager();
+        _;
+    }
+
+    /**
+     * @dev Only allow calls for a pool whose `hooks` is this contract.
+     *
+     * Functions that take a `PoolKey` from the caller should use this modifier, since the `poolManager` accepts any
+     * initialized pool and a pool configured with a different hook never calls into this contract.
+     */
+    modifier onlyValidPools(IHooks hooks) {
+        if (hooks != this) revert InvalidPool();
         _;
     }
 

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -744,6 +744,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     function _getCrossedTicks(PoolId poolId, int24 tickSpacing)
         internal
         view
+        virtual
         returns (int24 tickLower, int24 lower, int24 upper)
     {
         tickLower = _getTickLower(_getCurrentTick(poolId), tickSpacing);
@@ -770,7 +771,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      * @dev Get the tick lower. Takes a `tick` and `tickSpacing` and returns the nearest valid tick boundary
      * at or below the input tick, accounting for negative tick handling.
      */
-    function _getTickLower(int24 tick, int24 tickSpacing) internal pure returns (int24) {
+    function _getTickLower(int24 tick, int24 tickSpacing) internal pure virtual returns (int24) {
         // slither-disable-next-line divide-before-multiply
         int24 compressed = tick / tickSpacing;
         if (tick < 0 && tick % tickSpacing != 0) compressed--; // round towards negative infinity
@@ -781,7 +782,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      * @dev Get the current tick for a given pool. Takes a `PoolId` `poolId` and returns the tick the pool
      * stores, which is what marks whether a range is still active.
      */
-    function _getCurrentTick(PoolId poolId) internal view returns (int24 tick) {
+    function _getCurrentTick(PoolId poolId) internal view virtual returns (int24 tick) {
         (, tick,,) = poolManager.getSlot0(poolId);
     }
 
@@ -792,7 +793,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      * IMPORTANT: This value is part of a pool position's identity. Changing it on a deployed instance
      * strands the liquidity of every live order placed under the previous value.
      */
-    function _getPositionSalt(bool zeroForOne) internal pure returns (bytes32) {
+    function _getPositionSalt(bool zeroForOne) internal pure virtual returns (bytes32) {
         return zeroForOne ? bytes32(uint256(1)) : bytes32(0);
     }
 

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -8,7 +8,6 @@ import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {FullMath} from "@uniswap/v4-core/src/libraries/FullMath.sol";
 import {FixedPoint128} from "@uniswap/v4-core/src/libraries/FixedPoint128.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
-import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
@@ -44,7 +43,7 @@ library OrderIdLibrary {
 /**
  * @dev Limit Order Mechanism hook.
  *
- * Allows users to place limit orders at specific ticks outside of the current price range,
+ * Allows users to place limit orders at specific ticks the price has not yet crossed,
  * which will be filled if the pool's price crosses the order's tick.
  *
  * Note that given the way UniswapV4 pools works, when liquidity is added out of the current range,
@@ -123,6 +122,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     struct CancelCallbackData {
         PoolKey key;
         OrderIdLibrary.OrderId orderId;
+        bool zeroForOne;
         int24 tickLower;
         uint128 liquidity;
         address owner;
@@ -253,8 +253,17 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      * pool price crosses the specified `tick`. Takes a `PoolKey` `key`, target `tick`, direction `zeroForOne` indicating
      * whether to buy currency0 or currency1, and amount of `liquidity` to place. The interaction with the `poolManager` is done
      * via the `unlock` function, which will trigger the `{unlockCallback}` function.
+     *
+     * Requirements:
+     *
+     * - `key` must identify a pool configured with this hook, otherwise the order could never be filled.
+     * - The placement must require only the currency being sold, otherwise it reverts {InRange}.
      */
-    function placeOrder(PoolKey calldata key, int24 tick, bool zeroForOne, uint128 liquidity) public virtual {
+    function placeOrder(PoolKey calldata key, int24 tick, bool zeroForOne, uint128 liquidity)
+        public
+        virtual
+        onlyValidPools(key.hooks)
+    {
         if (liquidity == 0) revert ZeroLiquidity();
 
         OrderInfo storage orderInfo;
@@ -307,8 +316,16 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      * removed liquidity. Note that partial cancellation is not supported - the entire liquidity added by the msg.sender will be removed.
      * Note also that cancelling an order will cancel the order placed by the msg.sender, not orders placed by other users in the same tick range.
      * The interaction with the `poolManager` is done via the `unlock` function, which will trigger the `{unlockCallback}` function.
+     *
+     * Requirements:
+     *
+     * - `key` must identify a pool configured with this hook.
      */
-    function cancelOrder(PoolKey calldata key, int24 tickLower, bool zeroForOne, address to) public virtual {
+    function cancelOrder(PoolKey calldata key, int24 tickLower, bool zeroForOne, address to)
+        public
+        virtual
+        onlyValidPools(key.hooks)
+    {
         OrderIdLibrary.OrderId orderId = getOrderId(key, tickLower, zeroForOne);
         OrderInfo storage orderInfo = _orderInfos[orderId];
 
@@ -332,7 +349,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
             abi.encode(
                 CallbackData(
                     CallbackType.Cancel,
-                    abi.encode(CancelCallbackData(key, orderId, tickLower, liquidity, msg.sender, to))
+                    abi.encode(CancelCallbackData(key, orderId, zeroForOne, tickLower, liquidity, msg.sender, to))
                 )
             )
         );
@@ -429,7 +446,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
                 tickLower: placeData.tickLower,
                 tickUpper: placeData.tickLower + placeData.key.tickSpacing,
                 liquidityDelta: int256(uint256(placeData.liquidity)),
-                salt: 0
+                salt: _getPositionSalt(placeData.zeroForOne)
             }),
             ZERO_BYTES
         );
@@ -491,7 +508,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
                 tickLower: cancelData.tickLower,
                 tickUpper: cancelData.tickLower + cancelData.key.tickSpacing,
                 liquidityDelta: -int256(uint256(cancelData.liquidity)),
-                salt: 0
+                salt: _getPositionSalt(cancelData.zeroForOne)
             }),
             ZERO_BYTES
         );
@@ -586,7 +603,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
                     tickLower: tickLower,
                     tickUpper: tickLower + key.tickSpacing,
                     liquidityDelta: -int256(uint256(orderInfo.liquidityTotal)),
-                    salt: 0
+                    salt: _getPositionSalt(zeroForOne)
                 }),
                 ZERO_BYTES
             );
@@ -729,7 +746,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         view
         returns (int24 tickLower, int24 lower, int24 upper)
     {
-        tickLower = _getTickLower(_getTick(poolId), tickSpacing);
+        tickLower = _getTickLower(_getCurrentTick(poolId), tickSpacing);
         int24 tickLowerLast = getTickLowerLast(poolId);
 
         if (tickLower < tickLowerLast) {
@@ -761,12 +778,22 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     }
 
     /**
-     * @dev Get the current tick for a given pool. Takes a `PoolId` `poolId` and returns the tick calculated
-     * from the pool's current sqrt price.
+     * @dev Get the current tick for a given pool. Takes a `PoolId` `poolId` and returns the tick the pool
+     * stores, which is what marks whether a range is still active.
      */
-    function _getTick(PoolId poolId) internal view returns (int24 tick) {
-        (uint160 sqrtPriceX96,,,) = poolManager.getSlot0(poolId);
-        tick = TickMath.getTickAtSqrtPrice(sqrtPriceX96);
+    function _getCurrentTick(PoolId poolId) internal view returns (int24 tick) {
+        (, tick,,) = poolManager.getSlot0(poolId);
+    }
+
+    /**
+     * @dev Returns the salt of the pool position backing an order in direction `zeroForOne`. Both
+     * directions at one tick span the same range, so the salt is what keeps them in separate positions.
+     *
+     * IMPORTANT: This value is part of a pool position's identity. Changing it on a deployed instance
+     * strands the liquidity of every live order placed under the previous value.
+     */
+    function _getPositionSalt(bool zeroForOne) internal pure returns (bytes32) {
+        return zeroForOne ? bytes32(uint256(1)) : bytes32(0);
     }
 
     /**

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -16,6 +16,7 @@ import {FixedPoint128} from "@uniswap/v4-core/src/libraries/FixedPoint128.sol";
 import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 // Internal imports
+import {BaseHook} from "src/base/BaseHook.sol";
 import {LimitOrderHook, OrderIdLibrary} from "src/general/LimitOrderHook.sol";
 import {LimitOrderHookMock} from "../../src/mocks/general/LimitOrderHookMock.sol";
 import {HookTest} from "../utils/HookTest.sol";
@@ -132,9 +133,19 @@ contract LimitOrderHookTest is HookTest {
         return OrderIdLibrary.OrderId.unwrap(hook.getOrderId(poolKey, tickLower, zeroForOne));
     }
 
-    function getLiquidityInPosition(PoolKey memory poolKey, int24 tickLower) internal view returns (uint128) {
+    /// @dev The expected position salt per direction, stated here rather than read from the hook.
+    function positionSalt(bool zeroForOne) internal pure returns (bytes32) {
+        return zeroForOne ? bytes32(uint256(1)) : bytes32(0);
+    }
+
+    function getLiquidityInPosition(PoolKey memory poolKey, int24 tickLower, bool zeroForOne)
+        internal
+        view
+        returns (uint128)
+    {
         return manager.getPositionLiquidity(
-            poolKey.toId(), Position.calculatePositionKey(address(hook), tickLower, tickLower + tickSpacing, 0)
+            poolKey.toId(),
+            Position.calculatePositionKey(address(hook), tickLower, tickLower + tickSpacing, positionSalt(zeroForOne))
         );
     }
 
@@ -176,6 +187,16 @@ contract LimitOrderHookTest is HookTest {
         hook.placeOrder(key, 0, true, 0);
     }
 
+    function test_placeOrder_foreignPool_reverts() public {
+        vm.expectRevert(BaseHook.InvalidPool.selector);
+        hook.placeOrder(noHookKey, tickSpacing, true, 1e18);
+    }
+
+    function test_cancelOrder_foreignPool_reverts() public {
+        vm.expectRevert(BaseHook.InvalidPool.selector);
+        hook.cancelOrder(noHookKey, tickSpacing, false, address(this));
+    }
+
     function test_placeOrder_simple() public {
         int24 tickLower = 0;
         bool zeroForOne = true;
@@ -186,7 +207,7 @@ contract LimitOrderHookTest is HookTest {
         hook.placeOrder(key, tickLower, zeroForOne, liquidity);
 
         assertEq(rawOrderIdOf(key, tickLower, zeroForOne), 1, "first order should take order id 1");
-        assertEq(getLiquidityInPosition(key, tickLower), liquidity, "liquidity should be added to the pool");
+        assertEq(getLiquidityInPosition(key, tickLower, zeroForOne), liquidity, "liquidity should be added to the pool");
 
         OrderInfoView memory order = getOrderInfoView(1);
         assertFalse(order.filled, "order should not be filled");
@@ -220,7 +241,7 @@ contract LimitOrderHookTest is HookTest {
         hook.placeOrder(key, tickLower, true, liquidity);
 
         assertEq(rawOrderIdOf(key, tickLower, true), 1, "first order should take order id 1");
-        assertEq(getLiquidityInPosition(key, tickLower), liquidity, "liquidity should be added to the pool");
+        assertEq(getLiquidityInPosition(key, tickLower, true), liquidity, "liquidity should be added to the pool");
         assertEq(getOrderInfoView(1).liquidityTotal, liquidity, "liquidity total should be accounted");
     }
 
@@ -231,8 +252,61 @@ contract LimitOrderHookTest is HookTest {
         hook.placeOrder(key, tickLower, true, liquidity);
 
         assertEq(rawOrderIdOf(key, tickLower, true), 1, "first order should take order id 1");
-        assertEq(getLiquidityInPosition(key, tickLower), liquidity, "liquidity should be added to the pool");
+        assertEq(getLiquidityInPosition(key, tickLower, true), liquidity, "liquidity should be added to the pool");
         assertEq(getOrderInfoView(1).liquidityTotal, liquidity, "liquidity total should be accounted");
+    }
+
+    /**
+     * @dev At the exact boundary the pool counts the new liquidity as active, and the position is
+     * nonetheless entirely in the currency the order sells. Placing and cancelling moves no currency1
+     * in either direction, so a pro-rata split by liquidity is exact and the placement is single-sided
+     * in substance, not only in the accounting.
+     */
+    function test_placeOrder_leftBoundaryOfCurrentRange_positionIsWhollyTheSoldCurrency() public {
+        int24 tickLower = 0;
+        uint128 liquidity = 1e18;
+
+        (, int24 storedTick,,) = manager.getSlot0(key.toId());
+        assertEq(storedTick, tickLower, "the pool should count a position at this tick as active");
+
+        uint256 poolLiquidityBefore = manager.getLiquidity(key.toId());
+        uint256 balance1Before = currency1.balanceOf(address(this));
+        uint256 balance0Before = currency0.balanceOf(address(this));
+
+        hook.placeOrder(key, tickLower, true, liquidity);
+
+        assertEq(
+            manager.getLiquidity(key.toId()),
+            poolLiquidityBefore + liquidity,
+            "the placement should join the pool's active liquidity"
+        );
+        assertEq(currency1.balanceOf(address(this)), balance1Before, "the placement should not spend currency1");
+        assertLt(currency0.balanceOf(address(this)), balance0Before, "the placement should spend currency0");
+
+        hook.cancelOrder(key, tickLower, true, address(this));
+
+        assertEq(currency1.balanceOf(address(this)), balance1Before, "the cancel should not return currency1");
+        assertLe(
+            currency0.balanceOf(address(this)), balance0Before, "a place and cancel round trip should never pay out"
+        );
+        assertApproxEqAbs(
+            currency0.balanceOf(address(this)), balance0Before, 1, "the cancel should return the currency0 placed"
+        );
+    }
+
+    /// @dev Repeating the boundary round trip never pays the placer out, so the truncation dust cannot
+    /// be farmed by cycling placements at the current tick.
+    function test_placeOrder_leftBoundaryOfCurrentRange_roundTripNeverPaysOut() public {
+        uint256 balance0Before = currency0.balanceOf(address(this));
+        uint256 balance1Before = currency1.balanceOf(address(this));
+
+        for (uint256 i; i < 20; ++i) {
+            hook.placeOrder(key, 0, true, 1e18);
+            hook.cancelOrder(key, 0, true, address(this));
+
+            assertLe(currency0.balanceOf(address(this)), balance0Before, "a cycle paid out currency0");
+            assertLe(currency1.balanceOf(address(this)), balance1Before, "a cycle paid out currency1");
+        }
     }
 
     function test_placeOrder_crossedRange_reverts() public {
@@ -261,7 +335,7 @@ contract LimitOrderHookTest is HookTest {
         hook.placeOrder(key, tickLower, false, liquidity);
 
         assertEq(rawOrderIdOf(key, tickLower, false), 1, "first order should take order id 1");
-        assertEq(getLiquidityInPosition(key, tickLower), liquidity, "liquidity should be added to the pool");
+        assertEq(getLiquidityInPosition(key, tickLower, false), liquidity, "liquidity should be added to the pool");
         assertEq(getOrderInfoView(1).liquidityTotal, liquidity, "liquidity total should be accounted");
     }
 
@@ -293,7 +367,7 @@ contract LimitOrderHookTest is HookTest {
         hook.placeOrder(key, tickLower, true, liquidity);
 
         assertEq(rawOrderIdOf(key, tickLower, true), 1, "both placements should share order id 1");
-        assertEq(getLiquidityInPosition(key, tickLower), liquidity * 2, "liquidity should be added to the pool");
+        assertEq(getLiquidityInPosition(key, tickLower, true), liquidity * 2, "liquidity should be added to the pool");
         assertEq(getOrderInfoView(1).liquidityTotal, liquidity * 2, "liquidity total should be accounted");
         assertEq(hook.getUserInfo(OrderIdLibrary.OrderId.wrap(1), address(this)).liquidity, liquidity);
         assertEq(hook.getUserInfo(OrderIdLibrary.OrderId.wrap(1), user).liquidity, liquidity);
@@ -371,7 +445,7 @@ contract LimitOrderHookTest is HookTest {
         OrderInfoView memory order = getOrderInfoView(1);
         assertFalse(order.filled, "order should not be filled");
         assertEq(order.liquidityTotal, 0, "liquidity total should be 0");
-        assertEq(getLiquidityInPosition(key, tickLower), 0, "liquidity should be removed from the pool");
+        assertEq(getLiquidityInPosition(key, tickLower, true), 0, "liquidity should be removed from the pool");
         assertEq(rawOrderIdOf(key, tickLower, true), 0, "emptied order should be deactivated");
 
         assertApproxEqAbs(
@@ -406,7 +480,8 @@ contract LimitOrderHookTest is HookTest {
         accrueFeesWithoutFilling();
 
         // the swaps left fees pending in the pool position, to be collected by the cancellation
-        (int128 pending0, int128 pending1) = calculateFees(manager, key.toId(), address(hook), 0, tickSpacing, 0);
+        (int128 pending0, int128 pending1) =
+            calculateFees(manager, key.toId(), address(hook), 0, tickSpacing, positionSalt(true));
         assertTrue(pending0 > 0 || pending1 > 0, "fees should be pending in the order position");
 
         // cancelling pays out the same as removing the equivalent hookless position
@@ -465,7 +540,7 @@ contract LimitOrderHookTest is HookTest {
         OrderInfoView memory order = getOrderInfoView(1);
         assertFalse(order.filled, "order should not be filled");
         assertEq(order.liquidityTotal, 0, "liquidity total should be 0");
-        assertEq(getLiquidityInPosition(key, 0), 0, "liquidity should be removed from the pool");
+        assertEq(getLiquidityInPosition(key, 0, true), 0, "liquidity should be removed from the pool");
         assertEq(rawOrderIdOf(key, 0, true), 0, "emptied order should be deactivated");
     }
 
@@ -509,7 +584,7 @@ contract LimitOrderHookTest is HookTest {
         assertEq(order.principalCredited0, 0, "a zeroForOne fill should pay out only currency1");
         assertGt(order.principalCredited1, 0, "fill should credit the currency1 proceeds");
         assertEq(order.liquidityTotal, liquidity, "owners keep their liquidity accounted until withdrawal");
-        assertEq(getLiquidityInPosition(key, tickLower), 0, "fill should remove the liquidity from the pool");
+        assertEq(getLiquidityInPosition(key, tickLower, true), 0, "fill should remove the liquidity from the pool");
         assertEq(rawOrderIdOf(key, tickLower, true), 0, "filled order should be deactivated");
     }
 
@@ -556,10 +631,62 @@ contract LimitOrderHookTest is HookTest {
         assertFalse(order.filled, "order should not be filled");
         assertEq(order.principalCredited0, 0, "no principal should be credited");
         assertEq(order.principalCredited1, 0, "no principal should be credited");
-        assertEq(getLiquidityInPosition(key, tickLower), liquidity, "liquidity should remain in the pool");
+        assertEq(getLiquidityInPosition(key, tickLower, true), liquidity, "liquidity should remain in the pool");
 
         vm.expectRevert(LimitOrderHook.NotFilled.selector);
         hook.withdraw(OrderIdLibrary.OrderId.wrap(1), address(this));
+    }
+
+    /**
+     * @dev Places an order below spot, accrues fees on it with two-way flow, then lands the price exactly
+     * on the order's tick. `Pool.swap` stores that tick minus one for a downward landing on an initialized
+     * tick, which is what marks the order's range as no longer active.
+     */
+    function landOnOrdersTick(int24 orderTick, uint128 liquidity) internal {
+        modifyPoolLiquidity(key, -6000, 6000, 1e21, SALT_THIS);
+
+        vm.prank(user);
+        hook.placeOrder(key, orderTick, false, liquidity);
+
+        vm.startPrank(swapper);
+        for (uint256 i; i < 4; ++i) {
+            swapToLimit(key, true, -1e24, orderTick + 5);
+            swapToLimit(key, false, -1e24, -5);
+        }
+        swapToLimit(key, true, -1e24, orderTick);
+        vm.stopPrank();
+    }
+
+    /// @dev A downward landing exactly on an order's tick fills it, since the tick the pool stores marks
+    /// the order's liquidity as wholly converted. Reading the price-derived tick left the order live.
+    function test_fill_landingOnTheOrdersTick() public {
+        int24 orderTick = -tickSpacing;
+        landOnOrdersTick(orderTick, 1e18);
+
+        (uint160 sqrtPriceX96, int24 storedTick,,) = manager.getSlot0(key.toId());
+        assertEq(storedTick, orderTick - 1, "the pool should store the decremented tick");
+        assertEq(TickMath.getTickAtSqrtPrice(sqrtPriceX96), orderTick, "the price should still read the order's tick");
+
+        assertEq(getLiquidityInPosition(key, orderTick, false), 0, "the fill should empty the order's position");
+        assertEq(rawOrderIdOf(key, orderTick, false), 0, "a filled order should retire its key");
+    }
+
+    /// @dev The two directions at one tick span the same range, so the position salt is what stops a later
+    /// order from inheriting the position, and the fee balance, of the order filled out of the way.
+    function test_fill_oppositeDirectionAtSameTickDoesNotShareAPosition() public {
+        int24 orderTick = -tickSpacing;
+        uint128 liquidity = 1e18;
+        landOnOrdersTick(orderTick, liquidity);
+
+        vm.prank(attacker);
+        hook.placeOrder(key, orderTick, true, liquidity);
+
+        assertEq(getLiquidityInPosition(key, orderTick, true), liquidity, "the new order's position is not its own");
+        assertEq(getLiquidityInPosition(key, orderTick, false), 0, "the filled order's position should stay empty");
+
+        OrderInfoView memory order = getOrderInfoView(rawOrderIdOf(key, orderTick, true));
+        assertEq(order.accFee0PerLiqX128, 0, "the new order credited currency0 fees it did not earn");
+        assertEq(order.accFee1PerLiqX128, 0, "the new order credited currency1 fees it did not earn");
     }
 
     // ------------------------------------- Withdraw ------------------------------------- //

--- a/test/invariant/handlers/BaseHandler.sol
+++ b/test/invariant/handlers/BaseHandler.sol
@@ -138,8 +138,23 @@ abstract contract BaseHandler is Test {
 
     /// @dev Current tick rounded down to a multiple of `tickSpacing`, towards negative infinity.
     function _currentTickLower() internal view returns (int24) {
-        int24 tick = _currentTick();
+        return _floorToSpacing(_currentTick());
+    }
 
+    /// @dev Tick the pool stores in `slot0`, which is what `modifyLiquidity` branches on. A swap going
+    /// down sets it to `tickNext - 1` when it lands on an initialized tick, so it is not always the tick
+    /// the price maps to. Reading it keeps an assertion independent of the hook's own derivation.
+    function _storedTick() internal view returns (int24 tick) {
+        (, tick,,) = manager.getSlot0(poolId);
+    }
+
+    /// @dev `_storedTick` rounded down to a multiple of `tickSpacing`, towards negative infinity.
+    function _storedTickLower() internal view returns (int24) {
+        return _floorToSpacing(_storedTick());
+    }
+
+    /// @dev Rounds `tick` down to a multiple of `tickSpacing`, towards negative infinity.
+    function _floorToSpacing(int24 tick) private view returns (int24) {
         int24 compressed = tick / key.tickSpacing;
         if (tick < 0 && tick % key.tickSpacing != 0) compressed--;
 
@@ -154,6 +169,16 @@ abstract contract BaseHandler is Test {
     /// @dev Current tick lower of the pool.
     function currentTickLower() public view returns (int24) {
         return _currentTickLower();
+    }
+
+    /// @dev Tick the pool stores in `slot0`.
+    function storedTick() public view returns (int24) {
+        return _storedTick();
+    }
+
+    /// @dev Tick the pool stores in `slot0`, rounded down to a multiple of `tickSpacing`.
+    function storedTickLower() public view returns (int24) {
+        return _storedTickLower();
     }
 
     /// @dev Swap up to `amount` in through the router, stopping at `tickLimit`.

--- a/test/invariant/handlers/LimitOrderHook/LimitOrderHookHandler.sol
+++ b/test/invariant/handlers/LimitOrderHook/LimitOrderHookHandler.sol
@@ -7,6 +7,7 @@ import {IERC20Minimal} from "@uniswap/v4-core/src/interfaces/external/IERC20Mini
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {LimitOrderHook, OrderIdLibrary} from "src/general/LimitOrderHook.sol";
 import {LimitOrderHookMock} from "src/mocks/general/LimitOrderHookMock.sol";
@@ -78,6 +79,13 @@ contract LimitOrderHookHandler is BaseHandler {
     /// @dev Sticky record of every order that ever held multiple owners at once.
     mapping(uint232 orderId => bool) public ghost_hadMultipleOwners;
     uint256 public ghost_multipleOwnerCount;
+
+    /// @dev Count of placements made with the price exactly on the order's lower bound.
+    uint256 public ghost_boundaryPlacements;
+
+    /// @dev Of those, the ones the pool counts as in range, where its stored tick sits inside the new
+    /// position rather than one below it.
+    uint256 public ghost_inRangeBoundaryPlacements;
 
     /// @dev Entitlement per (order, placer) captured before the current action. Snapshot, not a
     /// ghost: only meaningful until the action's assertions run.
@@ -162,8 +170,18 @@ contract LimitOrderHookHandler is BaseHandler {
 
         uint128 liquidity = uint128(bound(liquiditySeed, LIQUIDITY_MIN_BOUND, LIQUIDITY_MAX_BOUND));
 
+        if (orderKey.zeroForOne && _atLowerBound(orderKey.tickLower)) {
+            ghost_boundaryPlacements++;
+            if (_storedTickIsInside(orderKey.tickLower)) ghost_inRangeBoundaryPlacements++;
+        }
+
+        uint256 balance0Before = _balanceOf(key.currency0, actor);
+        uint256 balance1Before = _balanceOf(key.currency1, actor);
+
         vm.prank(actor);
         hook.placeOrder(key, orderKey.tickLower, orderKey.zeroForOne, liquidity);
+
+        _INV_P_02_assertOneSidedContribution(actor, orderKey.zeroForOne, balance0Before, balance1Before);
 
         uint232 id = _orderId(orderKey.tickLower, orderKey.zeroForOne);
         ghost_orderIds.add(id, orderKey);
@@ -237,6 +255,26 @@ contract LimitOrderHookHandler is BaseHandler {
     }
 
     // ------------------ STATE TRANSITION INVARIANTS ------------------ //
+
+    /// @dev Asserts a placement contributes only the currency the order sells. Reads the placer's raw
+    /// balances rather than hook state, so the guard is checked against what the placer paid.
+    function _INV_P_02_assertOneSidedContribution(
+        address placer,
+        bool zeroForOne,
+        uint256 balance0Before,
+        uint256 balance1Before
+    ) private view {
+        uint256 balance0 = _balanceOf(key.currency0, placer);
+        uint256 balance1 = _balanceOf(key.currency1, placer);
+
+        if (zeroForOne) {
+            assertLt(balance0, balance0Before, "INV-P-02: a zeroForOne placement did not spend currency0");
+            assertEq(balance1, balance1Before, "INV-P-02: a zeroForOne placement spent currency1");
+        } else {
+            assertEq(balance0, balance0Before, "INV-P-02: a oneForZero placement spent currency0");
+            assertLt(balance1, balance1Before, "INV-P-02: a oneForZero placement did not spend currency1");
+        }
+    }
 
     /// @dev Captures every (order, placer) entitlement into the snap mappings.
     function _INV_S_02_snapshotEntitlements() private {
@@ -458,8 +496,40 @@ contract LimitOrderHookHandler is BaseHandler {
     /// @dev Whether `placeOrder` accepts this key at the current price: a `zeroForOne` order's range
     /// must sit strictly above the price, the reverse at or below it.
     function _placeable(int24 tickLower, bool zeroForOne) private view returns (bool) {
-        int24 current = _currentTick();
-        return zeroForOne ? current < tickLower : current >= tickLower + key.tickSpacing;
+        return zeroForOne ? _atOrBelowLowerBound(tickLower) : _atOrAboveUpperBound(tickLower);
+    }
+
+    /// @dev Whether the price is at or below the lower bound of the range starting at `tickLower`,
+    /// so a `zeroForOne` placement there costs only currency0.
+    ///
+    /// Compares prices rather than ticks: the tick still reads as `tickLower` for any price inside
+    /// it, but only the exact bound leaves the currency1 amount at zero. At that bound the pool counts
+    /// the position as in range and the hook accepts it anyway.
+    function _atOrBelowLowerBound(int24 tickLower) private view returns (bool) {
+        (uint160 sqrtPriceX96,,,) = manager.getSlot0(poolId);
+        return sqrtPriceX96 <= TickMath.getSqrtPriceAtTick(tickLower);
+    }
+
+    /// @dev Whether the price is at or above the upper bound of the range starting at `tickLower`,
+    /// so a `oneForZero` placement there costs only currency1. The upper bound itself is out of
+    /// range for the pool, so no boundary case arises on this side.
+    function _atOrAboveUpperBound(int24 tickLower) private view returns (bool) {
+        (uint160 sqrtPriceX96,,,) = manager.getSlot0(poolId);
+        return sqrtPriceX96 >= TickMath.getSqrtPriceAtTick(tickLower + key.tickSpacing);
+    }
+
+    /// @dev Whether the pool's stored tick sits inside the range starting at `tickLower`, so the pool
+    /// counts a position there as active liquidity. Reads `slot0.tick` rather than deriving it from the
+    /// price: a downward swap landing on `tickLower` stores `tickLower - 1` at that same price.
+    function _storedTickIsInside(int24 tickLower) private view returns (bool) {
+        (, int24 storedTick,,) = manager.getSlot0(poolId);
+        return storedTick >= tickLower && storedTick < tickLower + key.tickSpacing;
+    }
+
+    /// @dev Whether the price sits exactly on the lower bound of the range starting at `tickLower`.
+    function _atLowerBound(int24 tickLower) private view returns (bool) {
+        (uint160 sqrtPriceX96,,,) = manager.getSlot0(poolId);
+        return sqrtPriceX96 == TickMath.getSqrtPriceAtTick(tickLower);
     }
 
     /// @dev Liquidity `actor` owns in order `id`.

--- a/test/invariant/invariants/LimitOrderHook/LimitOrderHook.invariants.md
+++ b/test/invariant/invariants/LimitOrderHook/LimitOrderHook.invariants.md
@@ -1,133 +1,128 @@
 # Invariant Spec: LimitOrderHook lifecycle
 
-- **Target contract:** `src/general/LimitOrderHook.sol` (via `src/mocks/general/LimitOrderHookMock.sol`)
+- **Target:** `src/general/LimitOrderHook.sol`, via `src/mocks/general/LimitOrderHookMock.sol`
 - **Campaign:** `LimitOrderHookInvariants.t.sol`
-- **Status:** the `L`, `F`, `S` and `C` blocks hold. `P` (INV-P-01) is pending; no `A` invariants
-  are designed yet.
+- **Prefixes:** `L` live orders and price tracking, `F` the filled state, `P` placement and fee
+  entitlement, `C` cancellation, `S` solvency, `A` access control.
 
-> **Terminology.** An order carries one flag, `filled`, written only by `_fillOrder`. An order id is
-> **active** while `getOrderId` returns it (implies `filled == false`), **filled** when
-> `filled == true` (`_fillOrder` retires the key in the same call), and **cancelled** when its key
-> returns `ORDER_ID_DEFAULT` while `filled` is false, which only the cancel of the last liquidity
-> produces. A retired id is unreachable through the key mapping, so every invariant quantifies over a
-> handler-maintained id set.
+An order id is **active** while `getOrderId` returns it, **filled** once `_fillOrder` sets `filled` and
+retires the key in the same call, and **cancelled** when its key returns `ORDER_ID_DEFAULT` while
+`filled` is false. A retired id is unreachable through the key mapping, so every invariant quantifies
+over a handler-maintained id set.
 
-> **Prefixes.** `L` live orders and price tracking, `F` the filled state, `P` placement and fee
-> entitlement, `C` cancellation, `S` solvency, `A` access control.
-
-> **Fee accounting.** `accFee_cPerLiqX128` only ever increases. Each owner holds a checkpoint
-> `feeCheckpoint_cX128` and is owed `mulDiv(acc_c - ckpt_c, liq, Q128)`. Principal is tracked
-> separately as `principalCredited_c`, credited once by the fill and split pro-rata.
+`accFee_cPerLiqX128` only increases. Each owner holds a checkpoint `feeCheckpoint_cX128` and is owed
+`mulDiv(acc_c - ckpt_c, liq, Q128)`. Principal is tracked separately as `principalCredited_c`, credited
+once by the fill and split pro-rata.
 
 ## L: live orders and price tracking
 
 ### INV-L-01: An order's total liquidity equals the sum of its owners' liquidity
 
-- **predicate:** `∀o: liqTotal(o) == Σ_{a ∈ actors} liq(o, a)`
-- **status:** **holds.** 500 runs, 100k calls, 0 reverts.
-- The actor set is complete: the handler pranks every `placeOrder` as one of its own actors.
+- `∀o: liqTotal(o) == Σ_{a ∈ actors} liq(o, a)`
+- Holds. 500 runs, 100k calls.
 
 ### INV-L-02: An order is filled as soon as the price crosses its tick
 
-- **predicate:** `∀ active (t, d): d ? tickLowerNow <= t : tickLowerNow >= t`, where
-  `tickLowerNow = _getTickLower(currentTick, tickSpacing)`
-- **status:** **holds.** 500 runs, 100k calls, 0 reverts.
-- `tickLowerNow` is computed from the pool price, never from `getTickLowerLast`, so a drifted tracker
-  cannot make this agree with itself.
+- `∀ active (t, d): d ? tickLowerNow <= t : tickLowerNow >= t`, where
+  `tickLowerNow = _getTickLower(storedTick, tickSpacing)`
+- Holds. 10 runs, 5k calls.
+- `storedTick` is `slot0.tick`, which is what `Pool.modifyLiquidity` branches on. Reading it rather
+  than deriving from the price keeps the assertion independent of the hook's own derivation.
 
-### INV-L-03: The recorded tick lower tracks the pool price
+### INV-L-03: The recorded tick lower tracks the pool's stored tick
 
-- **predicate:** `getTickLowerLast(poolId) == _getTickLower(currentTick, tickSpacing)`
-- **status:** **holds.** 500 runs, 100k calls, 0 reverts.
+- `getTickLowerLast(poolId) == _getTickLower(storedTick, tickSpacing)`
+- Holds. 10 runs, 5k calls.
 - `_afterSwap` diffs the current tick against it, so drift leaves orders in the gap unfilled.
+
+### INV-L-04: A live order holds its pool position alone
+
+- `∀ live (t, d): positionLiquidity(hook, t, t + tickSpacing, salt(d)) == liqTotal(orderId(t, d))`
+- Holds. 10 runs, 5k calls.
+- Quantified over live orders only: a fill empties the position while `liquidityTotal` stays set until
+  the withdrawals.
+- Mutation checked: collapsing the position salt to `bytes32(0)` restores the shared position and
+  fails it.
 
 ## F: the filled state
 
 ### INV-F-01: A fully withdrawn order holds no liquidity
 
-- **predicate:** `∀o: fullyWithdrawn(o) ⟹ liqTotal(o) == 0`
-- **status:** **holds.** 500 runs, 100k calls, 0 reverts.
-- Not a restatement: `fullyWithdrawn` is the handler's owner count and reads neither `liquidityTotal`
-  nor `principalCredited`.
+- `∀o: fullyWithdrawn(o) ⟹ liqTotal(o) == 0`
+- Holds. 500 runs, 100k calls.
+- `fullyWithdrawn` is the handler's owner count, so this is not a restatement.
 
 ### INV-F-02: A fully withdrawn order has no remaining principal
 
-- **predicate:** `∀o: fullyWithdrawn(o) ⟹ principalCredited_c(o) == 0`
-- **status:** **holds.** 500 runs, 100k calls, 0 reverts.
-- Exact, no dust term: each withdrawal takes `mulDiv(P, l, L)` and the denominator shrinks alongside
-  the numerator, so the last owner out has `l == L` and carries off every earlier remainder.
-- The fee residual is out of scope: the last withdrawal deletes every `userInfo`, so no owed fees
-  remain to compare against.
+- `∀o: fullyWithdrawn(o) ⟹ principalCredited_c(o) == 0`
+- Holds. 500 runs, 100k calls.
+- Exact, no dust term: the last owner out has `l == L` and carries off every earlier remainder.
 
 ### INV-F-03: A filled order cannot be cancelled
 
-- **predicate as tested:** `∀ active (t, d): ¬filled(orderId(t, d))`
-- **status:** **holds.** 500 runs, 100k calls, 0 reverts.
-- `cancelOrder` resolves the id from the key. Once `_fillOrder` retires the key, a filled order is
-  unaddressable rather than guarded, and the revert is `ZeroLiquidity`.
+- `∀ active (t, d): ¬filled(orderId(t, d))`
+- Holds. 500 runs, 100k calls.
+- A filled order is unaddressable rather than guarded, since `_fillOrder` retires the key. The revert
+  is `ZeroLiquidity`.
 
 ## P: placement and fee entitlement
 
 ### INV-P-01: A first placement inherits no fees
 
-- **predicate:** `owed_c(o, X) == 0` after `placeOrder`, given `liq(o, X) == 0` before
-- **status:** not implemented.
-- Transition property over a single `placeOrder`, to be asserted in the handler around the call.
-- This is exactly H-01: entitlement begins at the placement, so any nonzero value is a transfer of
-  the existing owners' fees to the new placer.
-- Exact, no tolerance: a fresh owner has `liq == 0`, so the checkpoint is written at `acc` itself.
-- Informative only on an order that already accrued fees; trivially true otherwise.
+- `owed_c(o, X) == 0` after `placeOrder`, given `liq(o, X) == 0` before
+- Not implemented.
+
+### INV-P-02: A placement contributes only the currency the order sells
+
+- For every `placeOrder` by `X` in direction `d`:
+  `d ? (bal0(X) decreases ∧ bal1(X) unchanged) : (bal1(X) decreases ∧ bal0(X) unchanged)`
+- Holds. 10 runs, 5k calls.
+- Transition property, asserted in the handler around the call, against raw ERC-20 balances rather
+  than hook state.
+- Reaches the exact price boundary, where the pool counts a `zeroForOne` position as in range while
+  `amount1` is zero. `ghost_boundaryPlacements` counts those, and the campaign fails if none occur.
+- Mutation checked: removing `CrossedRange` from the place callback, with `_placeable` widened to
+  offer wrong-side placements, fails it.
 
 ## S: system solvency
 
 ### INV-S-01: The hook holds every amount it owes
 
-- **predicate:** `∀c: claims_c(hook) >= Σ_o [ principalCredited_c(o) + Σ_a owedFees_c(o,a) ]`, with
-  the surplus at most `ROUNDING_TOLERANCE`
-- **status:** **holds.** 500 runs, 100k calls, 0 reverts.
+- `∀c: claims_c(hook) >= Σ_o [ principalCredited_c(o) + Σ_a owedFees_c(o,a) ]`, surplus at most
+  `ROUNDING_TOLERANCE`
+- Holds. 500 runs, 100k calls.
 - A bound because credits and payout shares truncate. The surplus is bounded separately, so a leak
   cannot hide behind the tolerance.
-- Assumes the hook receives claims only from its own callbacks: no donations, no third-party minting.
+- Assumes the hook receives claims only from its own callbacks.
 
 ### INV-S-02: An action never reduces a non-caller's entitlement
 
-- **predicate:** for every action by `X`: `∀(o, a), a ≠ X: entitlement_c(o, a)_after >= entitlement_c(o, a)_before`,
+- For every action by `X`: `∀(o, a), a ≠ X: entitlement_c(o, a)_after >= entitlement_c(o, a)_before`,
   where `entitlement_c(o, a) = owedFees_c(o, a) + mulDiv(principalCredited_c(o), liq(o, a), liqTotal(o))`
-- **status:** **holds.** 3 runs, 900 calls, 0 reverts.
-- Transition property, asserted in the handler around every action (the `stateTransition` modifier).
-- The performing actor is exempt: exits collect their entitlement, and a top-up carries a wei of
-  checkpoint truncation. Swaps exempt nobody.
-- Exact for non-callers, no tolerance: their checkpoint and liquidity are untouched, the accumulators
-  only grow, and a withdrawal leaves its principal truncation dust to the remaining owners.
-- The handler recomputes entitlements from raw hook state (`getOrderInfo`, `getUserInfo`) rather
-  than through `feesOwed`/`principalOwed`, so a broken view cannot vouch for itself.
-- **mutation checked:** dropping the withdraw exemption fails immediately, so the assertion observes
-  real entitlement movement.
+- Holds. 3 runs, 900 calls.
+- Transition property, asserted around every action. The performing actor is exempt, since exits
+  collect their entitlement and a top-up carries a wei of checkpoint truncation. Swaps exempt nobody.
+- Recomputed from raw hook state, so a broken view cannot vouch for itself.
+- Mutation checked: dropping the withdraw exemption fails immediately.
 
 ## C: cancellation
 
 ### INV-C-01: An order id is reset only after the last canceller
 
-- **predicate:** `∀o: ¬filled(o) ⟹ ( keyRetired(o) ⟺ fullyCancelled(o) )`
-- **status:** **holds.** 500 runs, 100k calls, 0 reverts.
-- Both directions matter: a retired key over an owned order strands the owners; a live key over an
+- `∀o: ¬filled(o) ⟹ ( keyRetired(o) ⟺ fullyCancelled(o) )`
+- Holds. 500 runs, 100k calls.
+- Both directions matter: a retired key over an owned order strands the owners, a live key over an
   empty order is addressable with nothing to cancel.
-- Unfilled only: a fill retires the key while the liquidity is still recorded.
-- `keyRetired` compares the key mapping against the id, `fullyCancelled` is the handler's owner
-  count. Neither reads `liquidityTotal`.
-- **mutation checked:** retiring the key on a partial cancel (`liquidity <= liquidityTotal`) fails
-  within 30 runs.
+- Mutation checked: retiring the key on a partial cancel fails within 30 runs.
 
 ### INV-C-03: A fully cancelled order holds no liquidity
 
-- **predicate:** `∀o: fullyCancelled(o) ⟹ liqTotal(o) == 0`
-- **status:** **holds.** 500 runs, 100k calls, 0 reverts.
-- Not a restatement: `fullyCancelled` is the handler's owner count.
+- `∀o: fullyCancelled(o) ⟹ liqTotal(o) == 0`
+- Holds. 500 runs, 100k calls.
 
 ### INV-C-04: A fully cancelled order holds no principal
 
-- **predicate:** `∀o: fullyCancelled(o) ⟹ principalCredited_c(o) == 0`
-- **status:** **holds.** 500 runs, 100k calls, 0 reverts.
-- Only a fill credits principal, so the correct value is "never recorded", not "paid out". Fails if
-  the cancel path writes to the principal ledger.
-- **mutation checked:** adding `principalCredited0 += 1` to the cancel callback fails it.
+- `∀o: fullyCancelled(o) ⟹ principalCredited_c(o) == 0`
+- Holds. 500 runs, 100k calls.
+- Only a fill credits principal, so the correct value is "never recorded", not "paid out".
+- Mutation checked: adding `principalCredited0 += 1` to the cancel callback fails it.

--- a/test/invariant/invariants/LimitOrderHook/LimitOrderHookInvariants.t.sol
+++ b/test/invariant/invariants/LimitOrderHook/LimitOrderHookInvariants.t.sol
@@ -8,6 +8,7 @@ import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IERC20Minimal} from "@uniswap/v4-core/src/interfaces/external/IERC20Minimal.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {Position} from "@uniswap/v4-core/src/libraries/Position.sol";
 
 import {OrderIdLibrary} from "src/general/LimitOrderHook.sol";
 import {LimitOrderHookMock} from "src/mocks/general/LimitOrderHookMock.sol";
@@ -113,9 +114,11 @@ contract LimitOrderHookInvariantsTest is HookTest {
         }
     }
 
-    /// @dev INV-L-02: an order is filled as soon as the price crosses its tick.
+    /// @dev INV-L-02: an order is filled as soon as the price crosses its tick. Measured against the
+    /// tick the pool stores, not the one the hook derives from the price, so the two cannot agree by
+    /// sharing a derivation.
     function invariant_L02_noActiveOrderSurvivesThePriceCrossingIt() public view {
-        int24 tickLowerNow = handler.currentTickLower();
+        int24 tickLowerNow = handler.storedTickLower();
         int24[] memory ticks = handler.ticks();
 
         for (uint256 i; i < ticks.length; ++i) {
@@ -135,13 +138,46 @@ contract LimitOrderHookInvariantsTest is HookTest {
         }
     }
 
-    /// @dev INV-L-03: the recorded tick lower tracks the pool price. Drift leaves orders in the gap unfilled.
-    function invariant_L03_recordedTickLowerTracksThePoolPrice() public view {
+    /// @dev INV-L-03: the recorded tick lower tracks the pool's stored tick. Drift leaves orders in the
+    /// gap unfilled.
+    function invariant_L03_recordedTickLowerTracksThePoolTick() public view {
         assertEq(
             hook.getTickLowerLast(key.toId()),
-            handler.currentTickLower(),
-            "INV-L-03: the recorded tick lower does not match the pool price"
+            handler.storedTickLower(),
+            "INV-L-03: the recorded tick lower does not match the pool's stored tick"
         );
+    }
+
+    /// @dev INV-L-04: a live order's pool position holds exactly that order's liquidity.
+    function invariant_L04_liveOrderOwnsItsPositionAlone() public view {
+        int24[] memory tickList = handler.ticks();
+
+        for (uint256 i; i < tickList.length; ++i) {
+            _assertPositionHoldsOnlyTheOrder(tickList[i], true);
+            _assertPositionHoldsOnlyTheOrder(tickList[i], false);
+        }
+    }
+
+    /// @dev The expected position salt per direction, stated here rather than read from the hook.
+    function positionSalt(bool zeroForOne) internal pure returns (bytes32) {
+        return zeroForOne ? bytes32(uint256(1)) : bytes32(0);
+    }
+
+    /// @dev No-op when no order is live at the key.
+    function _assertPositionHoldsOnlyTheOrder(int24 tickLower, bool zeroForOne) private view {
+        uint232 id = handler.orderId(tickLower, zeroForOne);
+        if (id == 0) return;
+
+        (,,,,,,, uint128 liquidityTotal) = hook.getOrderInfo(OrderIdLibrary.OrderId.wrap(id));
+
+        uint128 positionLiquidity = manager.getPositionLiquidity(
+            key.toId(),
+            Position.calculatePositionKey(
+                address(hook), tickLower, tickLower + key.tickSpacing, positionSalt(zeroForOne)
+            )
+        );
+
+        assertEq(positionLiquidity, liquidityTotal, "INV-L-04: a live order does not hold its pool position alone");
     }
 
     /// @dev INV-F-01: a fully withdrawn order holds no liquidity.
@@ -330,11 +366,14 @@ contract LimitOrderHookInvariantsTest is HookTest {
         console.log("multi owner ratio", multiOwnerRatio, "%");
         console.log("multi withdrawer ratio", multiWithdrawerRatio, "%");
         console.log("multi canceller ratio", multiCancellerRatio, "%");
+        console.log("boundary placements", handler.ghost_boundaryPlacements());
+        console.log("in-range boundary placements", handler.ghost_inRangeBoundaryPlacements());
 
         assertGt(orderCount, 0, "no order was created");
         assertGt(fillCount, 0, "no order was filled");
         assertGt(fullyWithdrawnCount, 0, "no order was fully withdrawn");
         assertGt(fullyCancelledCount, 0, "no order was fully cancelled");
+        assertGt(handler.ghost_boundaryPlacements(), 0, "no order was placed at the price boundary");
     }
 
     /// @dev Orders whose exit was split across more than one actor.


### PR DESCRIPTION
Fixes L-08 by rejecting a `PoolKey` whose `hooks` is not this contract, through a new `onlyValidPools` in `BaseHook`.

Fixes M-08 by reading the pool's stored `slot0.tick` instead of deriving one from `sqrtPriceX96`, since a swap landing on an initialized tick going down stores `boundaryTick - 1`.

Addresses L-11 by stating the placement rule as a requirement on `placeOrder`: a placement must require only the currency being sold. The guard is unchanged, since a placement at the exact lower bound is still wholly one-sided. Covered by INV-P-02, which asserts one-sidedness against the placer's raw balances and now reaches that boundary.

Adds a per-direction position salt, so the two directions at one tick no longer share a pool position and a fee balance.