### PR TITLE
LimitOrderHook: L-08 scan only the ticks that hold an order

### DIFF
--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -8,6 +8,7 @@ import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
 import {FullMath} from "@uniswap/v4-core/src/libraries/FullMath.sol";
 import {FixedPoint128} from "@uniswap/v4-core/src/libraries/FixedPoint128.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {TickBitmap} from "@uniswap/v4-core/src/libraries/TickBitmap.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
@@ -156,6 +157,15 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
     /// @dev Tracks each order id for a given `orderKey`, defined by `keccak256` of the `poolKey`, `tickLower`, and `zeroForOne`.
     mapping(bytes32 orderKey => OrderIdLibrary.OrderId orderId) private _orderIds;
+
+    /**
+     * @dev Tracks which ticks hold a live order, one bitmap per pool and direction.
+     *
+     * A tick whose bit is clear is never visited, so its order would never fill while its liquidity
+     * converted. Keying by direction lets each order own its bit outright, with no need to check the
+     * opposite direction before clearing.
+     */
+    mapping(PoolId poolId => mapping(bool zeroForOne => mapping(int16 wordPos => uint256 word))) private _orderTicks;
 
     /// @dev Tracks the order info for each order id.
     mapping(OrderIdLibrary.OrderId orderId => OrderInfo orderInfo) private _orderInfos;
@@ -586,8 +596,21 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         _tickLowerLasts[poolId] = tickLower;
 
         bool zeroForOne = !swapZeroForOne;
-        for (; lower <= upper; lower += key.tickSpacing) {
-            _fillOrder(key, lower, zeroForOne);
+        mapping(int16 => uint256) storage orderTicks = _orderTicks[poolId][zeroForOne];
+
+        // the scan looks strictly above the tick it is given, so the lower bound is filled first
+        _fillOrder(key, lower, zeroForOne);
+
+        int24 tick = lower;
+        while (tick < upper) {
+            // `next` is strictly above `tick`, whether or not it holds an order, so this terminates
+            (int24 next, bool initialized) =
+                TickBitmap.nextInitializedTickWithinOneWord(orderTicks, tick, key.tickSpacing, false);
+
+            if (next > upper) break;
+            if (initialized) _fillOrder(key, next, zeroForOne);
+
+            tick = next;
         }
     }
 
@@ -777,9 +800,21 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     /**
      * @dev Internal helper that updates the order ID mapping. Takes a `PoolKey` `key`, target `tickLower`, direction
      * `zeroForOne`, and `orderId` to store. Associates the given order id with the pool position's hash.
+     *
+     * The only writer of both the order id and its bit. The bit is flipped from the transition observed
+     * here, not from the caller's intent, so writing the same liveness twice leaves the bitmap alone.
      */
     function _setOrderId(PoolKey memory key, int24 tickLower, bool zeroForOne, OrderIdLibrary.OrderId orderId) private {
-        _orderIds[keccak256(abi.encode(key, tickLower, zeroForOne))] = orderId;
+        bytes32 orderKey = keccak256(abi.encode(key, tickLower, zeroForOne));
+
+        bool wasLive = !_orderIds[orderKey].equals(ORDER_ID_DEFAULT);
+        bool isLive = !orderId.equals(ORDER_ID_DEFAULT);
+
+        _orderIds[orderKey] = orderId;
+
+        if (wasLive != isLive) {
+            TickBitmap.flipTick(_orderTicks[key.toId()][zeroForOne], tickLower, key.tickSpacing);
+        }
     }
 
     /**
@@ -818,6 +853,16 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      */
     function getTickLowerLast(PoolId poolId) public view returns (int24) {
         return _tickLowerLasts[poolId];
+    }
+
+    /// @dev Returns whether `tickLower` is recorded as holding a live order in direction `zeroForOne`.
+    function _hasOrderAtTick(PoolId poolId, int24 tickSpacing, int24 tickLower, bool zeroForOne)
+        internal
+        view
+        returns (bool)
+    {
+        (int16 wordPos, uint8 bitPos) = TickBitmap.position(TickBitmap.compress(tickLower, tickSpacing));
+        return _orderTicks[poolId][zeroForOne][wordPos] & (uint256(1) << bitPos) != 0;
     }
 
     /**

--- a/src/mocks/general/LimitOrderHookMock.sol
+++ b/src/mocks/general/LimitOrderHookMock.sol
@@ -20,6 +20,10 @@ contract LimitOrderHookMock is LimitOrderHook {
 
     constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
 
+    function hasOrderAtTick(PoolKey memory key, int24 tickLower, bool zeroForOne) external view returns (bool) {
+        return _hasOrderAtTick(key.toId(), key.tickSpacing, tickLower, zeroForOne);
+    }
+
     /**
      * @dev Swaps `amount` toward `targetTick` from inside this hook's own unlock callback, which the pool
      * does not report. Fills the orders it crossed when `fillCrossed`, and models the subclass that forgets

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -802,6 +802,43 @@ contract LimitOrderHookTest is HookTest {
         assertLt(used, 3_000_000, "a 5000 spacing move should not cost a lookup per tick");
     }
 
+    /// @dev A word of the bitmap spans 256 spaced ticks, so a scan that steps past one must not lose the
+    /// orders on either side of the seam.
+    function test_fill_scanCrossesAWordBoundary() public {
+        PoolKey memory wordKey = PoolKey({
+            currency0: currency0, currency1: currency1, fee: 3000, tickSpacing: 1, hooks: IHooks(address(hook))
+        });
+        manager.initialize(wordKey, TickMath.getSqrtPriceAtTick(0));
+
+        // at a spacing of one, ticks 255 and 256 sit in adjacent words
+        hook.placeOrder(wordKey, 255, true, 1e12);
+        hook.placeOrder(wordKey, 256, true, 1e12);
+        uint232 below = rawOrderIdOf(wordKey, 255, true);
+        uint232 above = rawOrderIdOf(wordKey, 256, true);
+
+        vm.prank(swapper);
+        swapToLimit(wordKey, false, -1e21, 300);
+
+        assertGt(getCurrentTick(wordKey), 256, "the price should be past both orders");
+        assertTrue(getOrderInfoView(below).filled, "the order below the seam should fill");
+        assertTrue(getOrderInfoView(above).filled, "the order above the seam should fill");
+    }
+
+    /// @dev Negative ticks compress to negative word positions, which the scan must index the same way.
+    function test_fill_scanOverNegativeTicks() public {
+        hook.placeOrder(key, -60, false, 1e15);
+        hook.placeOrder(key, -180, false, 1e15);
+        uint232 near = rawOrderIdOf(key, -60, false);
+        uint232 far = rawOrderIdOf(key, -180, false);
+
+        vm.prank(swapper);
+        swapToLimit(key, true, -1e21, -240);
+
+        assertLt(getCurrentTick(key), -180, "the price should be past both orders");
+        assertTrue(getOrderInfoView(near).filled, "the nearer negative order should fill");
+        assertTrue(getOrderInfoView(far).filled, "the further negative order should fill");
+    }
+
     // ------------------------------------- Withdraw ------------------------------------- //
 
     function test_withdraw_notFilled_reverts() public {

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -769,6 +769,39 @@ contract LimitOrderHookTest is HookTest {
         assertEq(getLiquidityInPosition(key, orderTick, true), liquidity, "liquidity should stay in the pool");
     }
 
+    /// @dev The scan searches strictly above the tick it holds, so the range's own upper bound is the
+    /// tick it can most easily miss. An order there is converted and must fill; one above it must not.
+    function test_fill_orderOnTheScannedRangesUpperBoundFills() public {
+        int24 onBound = 50 * tickSpacing;
+        int24 above = 51 * tickSpacing;
+
+        hook.placeOrder(key, onBound, true, 1e15);
+        hook.placeOrder(key, above, true, 1e15);
+
+        modifyPoolLiquidity(key, -600000, 600000, 1e21, SALT_THIS);
+
+        vm.prank(swapper);
+        swapToLimit(key, false, -1e24, above);
+
+        assertEq(hook.getTickLowerLast(key.toId()) - tickSpacing, onBound, "the range's upper bound moved");
+        assertEq(rawOrderIdOf(key, onBound, true), 0, "the order on the upper bound was skipped");
+        assertEq(rawOrderIdOf(key, above, true), 2, "an order above the range was filled");
+    }
+
+    /// @dev The scan visits ticks holding an order, not every tick crossed, so a wide move stays cheap
+    /// even with no orders to fill. Reading one slot per tick made this exceed the block gas limit.
+    function test_fill_wideBandCostsFarLessThanABlock() public {
+        modifyPoolLiquidity(key, -600000, 600000, 1e21, SALT_THIS);
+
+        uint256 before = gasleft();
+        vm.prank(swapper);
+        swapToLimit(key, true, -1e27, -300000);
+        uint256 used = before - gasleft();
+
+        assertLt(getCurrentTick(key), -200000, "the swap should cover a wide band");
+        assertLt(used, 3_000_000, "a 5000 spacing move should not cost a lookup per tick");
+    }
+
     // ------------------------------------- Withdraw ------------------------------------- //
 
     function test_withdraw_notFilled_reverts() public {

--- a/test/invariant/handlers/LimitOrderHook/LimitOrderHookHandler.sol
+++ b/test/invariant/handlers/LimitOrderHook/LimitOrderHookHandler.sol
@@ -8,6 +8,7 @@ import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {TickBitmap} from "@uniswap/v4-core/src/libraries/TickBitmap.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {LimitOrderHook, OrderIdLibrary} from "src/general/LimitOrderHook.sol";
 import {LimitOrderHookMock} from "src/mocks/general/LimitOrderHookMock.sol";
@@ -86,6 +87,11 @@ contract LimitOrderHookHandler is BaseHandler {
     /// @dev Of those, the ones the pool counts as in range, where its stored tick sits inside the new
     /// position rather than one below it.
     uint256 public ghost_inRangeBoundaryPlacements;
+
+    /// @dev The widest span, in bitmap words, that a single swap's crossed range covered, and how many
+    /// swaps covered more than one.
+    uint256 public ghost_maxWordSpanCrossed;
+    uint256 public ghost_multiWordCrossings;
 
     /// @dev Entitlement per (order, placer) captured before the current action. Snapshot, not a
     /// ghost: only meaningful until the action's assertions run.
@@ -230,6 +236,25 @@ contract LimitOrderHookHandler is BaseHandler {
         vm.assume(target != current);
 
         _swap(target < current, bound(amountSeed, AMOUNT_MIN_BOUND, AMOUNT_MAX_BOUND), target);
+    }
+
+    /// @dev Records the bitmap words a swap's crossed range spanned.
+    function _swap(bool zeroForOne, uint256 amount, int24 tickLimit) internal override {
+        int24 before = hook.getTickLowerLast(key.toId());
+
+        super._swap(zeroForOne, amount, tickLimit);
+
+        int24 last = hook.getTickLowerLast(key.toId());
+        if (before == last) return;
+
+        (int16 wordBefore,) = TickBitmap.position(TickBitmap.compress(before, key.tickSpacing));
+        (int16 wordLast,) = TickBitmap.position(TickBitmap.compress(last, key.tickSpacing));
+
+        int16 distance = wordBefore > wordLast ? wordBefore - wordLast : wordLast - wordBefore;
+        uint256 span = uint256(uint16(distance)) + 1;
+
+        if (span > ghost_maxWordSpanCrossed) ghost_maxWordSpanCrossed = span;
+        if (span > 1) ++ghost_multiWordCrossings;
     }
 
     /// @dev Moves the price from inside the hook's own unlock callback, which the pool does not report,

--- a/test/invariant/invariants/LimitOrderHook/LimitOrderHook.invariants.md
+++ b/test/invariant/invariants/LimitOrderHook/LimitOrderHook.invariants.md
@@ -44,6 +44,15 @@ once by the fill and split pro-rata.
 - Mutation checked: collapsing the position salt to `bytes32(0)` restores the shared position and
   fails it.
 
+### INV-L-05: A tick is recorded as holding an order exactly when one is live there
+
+- `∀ (t, d) in the handler's tick set: hasOrderAtTick(t, d) ⟺ orderId(t, d) != 0`
+- Holds. 10 runs, 5k calls.
+- The fill scan visits only recorded ticks, so a live order whose bit is clear is never filled while its
+  liquidity converts, leaving its owner a free option to cancel after a round trip.
+- Mutation checked: sensitive to a single-tick desync at 10 runs. `ghost_multiWordCrossings` is a
+  coverage floor, so the campaign fails if no swap ever crosses a word boundary.
+
 ## F: the filled state
 
 ### INV-F-01: A fully withdrawn order holds no liquidity

--- a/test/invariant/invariants/LimitOrderHook/LimitOrderHookInvariants.t.sol
+++ b/test/invariant/invariants/LimitOrderHook/LimitOrderHookInvariants.t.sol
@@ -182,6 +182,29 @@ contract LimitOrderHookInvariantsTest is HookTest {
         assertEq(positionLiquidity, liquidityTotal, "INV-L-04: a live order does not hold its pool position alone");
     }
 
+    /// @dev INV-L-05: a tick is recorded as holding an order exactly when one is live there.
+    function invariant_L05_recordedTickAgreesWithTheOrder() public view {
+        int24[] memory tickList = handler.ticks();
+
+        for (uint256 i; i < tickList.length; ++i) {
+            _assertRecordedTickAgrees(tickList[i], true);
+            _assertRecordedTickAgrees(tickList[i], false);
+        }
+    }
+
+    /// @dev The fill scan visits a tick only when it is recorded, so a tick holding a live order whose
+    /// bit is clear is never filled. Its liquidity converts while the order stays live, and its owner
+    /// can cancel after a round trip through the range and take back what they deposited.
+    function _assertRecordedTickAgrees(int24 tickLower, bool zeroForOne) private view {
+        bool live = OrderIdLibrary.OrderId.unwrap(hook.getOrderId(key, tickLower, zeroForOne)) != 0;
+
+        assertEq(
+            hook.hasOrderAtTick(key, tickLower, zeroForOne),
+            live,
+            "INV-L-05: a tick's record disagrees with whether an order is live there"
+        );
+    }
+
     /// @dev INV-F-01: a fully withdrawn order holds no liquidity.
     function invariant_F01_fullyWithdrawnOrderHoldsNoLiquidity() public view {
         uint232[] memory ids = handler.orderIds();
@@ -370,12 +393,15 @@ contract LimitOrderHookInvariantsTest is HookTest {
         console.log("multi canceller ratio", multiCancellerRatio, "%");
         console.log("boundary placements", handler.ghost_boundaryPlacements());
         console.log("in-range boundary placements", handler.ghost_inRangeBoundaryPlacements());
+        console.log("widest word span crossed by one swap", handler.ghost_maxWordSpanCrossed());
+        console.log("swaps crossing more than one word", handler.ghost_multiWordCrossings());
 
         assertGt(orderCount, 0, "no order was created");
         assertGt(fillCount, 0, "no order was filled");
         assertGt(fullyWithdrawnCount, 0, "no order was fully withdrawn");
         assertGt(fullyCancelledCount, 0, "no order was fully cancelled");
         assertGt(handler.ghost_boundaryPlacements(), 0, "no order was placed at the price boundary");
+        assertGt(handler.ghost_multiWordCrossings(), 0, "no swap crossed a word, so the scan never advanced");
     }
 
     /// @dev Orders whose exit was split across more than one actor.


### PR DESCRIPTION
Fixes L-08: Linear tick scanning makes wide swaps run out of gas

The fill scan read one slot per tick between the recorded tick and the price, so its cost followed the
distance a swap covered rather than the orders it crossed. A wide move on a pool with small spacing
exceeded the block gas limit, and every swap on the pool then reverted.

A bitmap per pool and direction records which ticks hold a live order, so the scan skips a whole word of
empty ticks per read. On a `tickSpacing = 1` pool, a swap crossing 3000 ticks with 3 orders goes from
15,184,560 to 699,340 gas. Adds INV-L-05. Reported as M-13 in the previous scan.
