### PR TITLE
ReHypothecationHook: restrict liquidity provision and redefine shares

### DIFF
--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -99,6 +99,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /// @dev The offset of the just-in-time position upper tick within {REHYPOTHECATION_HOOK_SLOT}.
     uint256 private constant TICK_UPPER_OFFSET = 1;
 
+    /// @dev The offset of the swap-cycle lock flag within {REHYPOTHECATION_HOOK_SLOT}.
+    uint256 private constant SWAP_CYCLE_OFFSET = 2;
+
     /// @dev Error thrown when trying to initialize a pool that has already been initialized.
     error AlreadyInitialized();
 
@@ -125,6 +128,10 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
 
     /// @dev Error thrown when a seed would mint fewer than the minimum safe initial `shares`, given `minShares`.
     error InsufficientSeed(uint256 shares, uint256 minShares);
+
+    /// @dev Error thrown when a liquidity operation and a swap cycle would overlap, to prevent reentrancy
+    /// across the just-in-time settlement.
+    error Locked();
 
     /**
      * @dev Emitted when a `sender` adds rehypothecated `shares` to the `poolKey` pool,
@@ -153,12 +160,25 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * @dev Initialize the hook's `poolKey` pool. The key stored by the hook is unique and
      * should not be modified so that it can safely be used across the hook's lifecycle.
      * Note that the hook supports only one pool key.
+     *
+     * WARNING: The first initialization permanently binds the hook to the pool it observes. Since pool
+     * initialization is permissionless, a third party could front-run and bind the hook to an unintended pool.
+     * Deployers should initialize the pool atomically with the hook's deployment to avoid this, and may
+     * override {_validatePoolKey} to enforce the expected pool key.
      */
     function _beforeInitialize(address, PoolKey calldata key, uint160) internal virtual override returns (bytes4) {
         if (address(_poolKey.hooks) != address(0)) revert AlreadyInitialized();
+        _validatePoolKey(key);
         _poolKey = key;
         return this.beforeInitialize.selector;
     }
+
+    /**
+     * @dev Validates the `key` the hook is about to bind to on first initialization. Defaults to accepting any
+     * key; override to restrict the hook to an expected pool (e.g. specific currencies, fee or tick spacing)
+     * and defend against front-run binding. See {_beforeInitialize}.
+     */
+    function _validatePoolKey(PoolKey calldata key) internal view virtual {}
 
     /**
      * @dev Seeds the pool with its first liquidity, depositing `amount0` of `currency0` and `amount1` of
@@ -190,6 +210,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         returns (uint256 shares, BalanceDelta delta)
     {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
+        if (_inSwapCycle()) revert Locked();
         if (totalSupply() != 0) revert AlreadySeeded();
 
         shares = Math.sqrt(amount0 * amount1);
@@ -232,6 +253,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         returns (BalanceDelta delta)
     {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
+        if (_inSwapCycle()) revert Locked();
         if (totalSupply() == 0) revert NotSeeded();
         if (shares == 0) revert ZeroShares();
 
@@ -266,6 +288,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      */
     function removeReHypothecatedLiquidity(uint256 shares) public virtual nonReentrant returns (BalanceDelta delta) {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
+        if (_inSwapCycle()) revert Locked();
         if (shares == 0) revert ZeroShares();
 
         (uint256 amount0, uint256 amount1) = previewRedeem(shares);
@@ -305,6 +328,11 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {
+        // Lock the swap cycle: block liquidity operations from reentering mid-settlement, and block a swap
+        // from running inside a liquidity operation or another swap cycle. Cleared at the end of `_afterSwap`.
+        if (_reentrancyGuardEntered() || _inSwapCycle()) revert Locked();
+        _setSwapCycle(true);
+
         // Snapshot the position's tick bounds so `afterSwap` removes exactly what is added here.
         _snapshotActiveTicks();
 
@@ -342,6 +370,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
             _resolveHookDelta(key.currency0);
             _resolveHookDelta(key.currency1);
         }
+
+        // Unlock the swap cycle once settlement (and its external yield-source calls) is complete.
+        _setSwapCycle(false);
 
         return (this.afterSwap.selector, 0);
     }
@@ -505,6 +536,16 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /// @dev The upper tick of the just-in-time position snapshotted for the current swap.
     function _activeTickUpper() private view returns (int24) {
         return int24(REHYPOTHECATION_HOOK_SLOT.offset(TICK_UPPER_OFFSET).asInt256().tload());
+    }
+
+    /// @dev Sets whether a swap cycle (`beforeSwap` through `afterSwap`) is currently in progress.
+    function _setSwapCycle(bool active) private {
+        REHYPOTHECATION_HOOK_SLOT.offset(SWAP_CYCLE_OFFSET).asBoolean().tstore(active);
+    }
+
+    /// @dev Whether a swap cycle is currently in progress.
+    function _inSwapCycle() private view returns (bool) {
+        return REHYPOTHECATION_HOOK_SLOT.offset(SWAP_CYCLE_OFFSET).asBoolean().tload();
     }
 
     /**

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -10,6 +10,8 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
+import {TransientSlot} from "@openzeppelin/contracts/utils/TransientSlot.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {Position} from "@uniswap/v4-core/src/libraries/Position.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
@@ -78,9 +80,24 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     using SafeCast for *;
     using Math for uint256;
     using SafeERC20 for IERC20;
+    using TransientSlot for *;
+    using SlotDerivation for *;
 
     /// @dev The pool key for the hook. Note that the hook supports only one pool key.
     PoolKey private _poolKey;
+
+    /*
+     * @dev The ERC-7201 namespaced transient storage slot for this hook.
+     * keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ReHypothecationHook")) - 1)) & ~bytes32(uint256(0xff))
+    */
+    bytes32 private constant REHYPOTHECATION_HOOK_SLOT =
+        0x23f8264cc98f1c05acfa1795f9fb9efa795bb6c05987a0477bcc1622ab5aca00;
+
+    /// @dev The offset of the just-in-time position lower tick within {REHYPOTHECATION_HOOK_SLOT}.
+    uint256 private constant TICK_LOWER_OFFSET = 0;
+
+    /// @dev The offset of the just-in-time position upper tick within {REHYPOTHECATION_HOOK_SLOT}.
+    uint256 private constant TICK_UPPER_OFFSET = 1;
 
     /// @dev Error thrown when trying to initialize a pool that has already been initialized.
     error AlreadyInitialized();
@@ -223,8 +240,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         _transferFromSenderToHook(_poolKey.currency0, amount0, msg.sender);
         _transferFromSenderToHook(_poolKey.currency1, amount1, msg.sender);
 
-        _depositToYieldSource(_poolKey.currency0, amount0);
-        _depositToYieldSource(_poolKey.currency1, amount1);
+        // Skip zero-amount deposits, which some yield sources reject (e.g. when one side is proportionally empty)
+        if (amount0 > 0) _depositToYieldSource(_poolKey.currency0, amount0);
+        if (amount1 > 0) _depositToYieldSource(_poolKey.currency1, amount1);
 
         _mint(msg.sender, shares);
 
@@ -254,8 +272,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
 
         _burn(msg.sender, shares);
 
-        _withdrawFromYieldSource(_poolKey.currency0, amount0);
-        _withdrawFromYieldSource(_poolKey.currency1, amount1);
+        // Skip zero-amount withdrawals, which some yield sources reject (e.g. when one side is proportionally empty)
+        if (amount0 > 0) _withdrawFromYieldSource(_poolKey.currency0, amount0);
+        if (amount1 > 0) _withdrawFromYieldSource(_poolKey.currency1, amount1);
 
         _transferFromHookToSender(_poolKey.currency0, amount0, msg.sender);
         _transferFromHookToSender(_poolKey.currency1, amount1, msg.sender);
@@ -286,6 +305,10 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {
+        // Snapshot the position's tick bounds so `afterSwap` removes exactly what is added here, even if the
+        // tick getters are overridden to depend on mutable pool state that the swap then moves.
+        _snapshotActiveTicks();
+
         // Get the liquidity to be used from the amounts currently deposited in the yield sources
         uint256 liquidityToUse = _getLiquidityToUse();
         if (liquidityToUse > 0) _modifyLiquidity(liquidityToUse.toInt256());
@@ -467,6 +490,25 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     }
 
     /**
+     * @dev Snapshots the just-in-time position's tick bounds into transient storage, so the same bounds are used
+     * to add, read and remove the position across a swap. Called at the start of `beforeSwap`.
+     */
+    function _snapshotActiveTicks() private {
+        REHYPOTHECATION_HOOK_SLOT.offset(TICK_LOWER_OFFSET).asInt256().tstore(getTickLower());
+        REHYPOTHECATION_HOOK_SLOT.offset(TICK_UPPER_OFFSET).asInt256().tstore(getTickUpper());
+    }
+
+    /// @dev The lower tick of the just-in-time position snapshotted for the current swap.
+    function _activeTickLower() private view returns (int24) {
+        return int24(REHYPOTHECATION_HOOK_SLOT.offset(TICK_LOWER_OFFSET).asInt256().tload());
+    }
+
+    /// @dev The upper tick of the just-in-time position snapshotted for the current swap.
+    function _activeTickUpper() private view returns (int24) {
+        return int24(REHYPOTHECATION_HOOK_SLOT.offset(TICK_UPPER_OFFSET).asInt256().tload());
+    }
+
+    /**
      * @dev Retrieves the current `liquidity` of the hook owned liquidity position in the `_poolKey` pool.
      *
      * NOTE: Given that just-in-time liquidity provisioning is performed, this function will only return non-zero values
@@ -475,7 +517,8 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * {_getAmountInYieldSource}.
      */
     function _getHookPositionLiquidity() internal view virtual returns (uint128 liquidity) {
-        bytes32 positionKey = Position.calculatePositionKey(address(this), getTickLower(), getTickUpper(), bytes32(0));
+        bytes32 positionKey =
+            Position.calculatePositionKey(address(this), _activeTickLower(), _activeTickUpper(), bytes32(0));
         return poolManager.getPositionLiquidity(_poolKey.toId(), positionKey);
     }
 
@@ -498,7 +541,8 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     }
 
     /**
-     * @dev Modifies the hook's liquidity position in the pool.
+     * @dev Modifies the hook's liquidity position in the pool, at the tick bounds snapshotted for the current
+     * swap (see {_snapshotActiveTicks}).
      *
      * Positive liquidityDelta adds liquidity, while negative removes it.
      */
@@ -506,7 +550,10 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         (delta,) = poolManager.modifyLiquidity(
             _poolKey,
             ModifyLiquidityParams({
-                tickLower: getTickLower(), tickUpper: getTickUpper(), liquidityDelta: liquidityDelta, salt: bytes32(0)
+                tickLower: _activeTickLower(),
+                tickUpper: _activeTickUpper(),
+                liquidityDelta: liquidityDelta,
+                salt: bytes32(0)
             }),
             ""
         );

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -333,7 +333,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         _snapshotActiveTicks();
 
         // Get the liquidity to be used from the amounts currently deposited in the yield sources
-        uint256 liquidityToUse = _getLiquidityToUse();
+        uint256 liquidityToUse = _getLiquidityToUse(_activeTickLower(), _activeTickUpper());
         if (liquidityToUse > 0) _modifyLiquidity(liquidityToUse.toInt256());
 
         return (this.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
@@ -503,13 +503,16 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * NOTE: Since liquidity is provided and withdrawn transiently during flash accounting, it can be virtually
      * inflated for performing "leveraged liquidity" strategies, which would give better pricing to swappers at
      * the cost of the profitability of LP's and increased risks.
+     *
+     * @param tickLower The lower tick of the position the liquidity is sized for.
+     * @param tickUpper The upper tick of the position the liquidity is sized for.
      */
-    function _getLiquidityToUse() internal view virtual returns (uint256) {
+    function _getLiquidityToUse(int24 tickLower, int24 tickUpper) internal view virtual returns (uint256) {
         (uint160 currentSqrtPriceX96,,,) = poolManager.getSlot0(_poolKey.toId());
         return LiquidityAmounts.getLiquidityForAmounts(
             currentSqrtPriceX96,
-            TickMath.getSqrtPriceAtTick(getTickLower()),
-            TickMath.getSqrtPriceAtTick(getTickUpper()),
+            TickMath.getSqrtPriceAtTick(tickLower),
+            TickMath.getSqrtPriceAtTick(tickUpper),
             _getMaxWithdrawFromYieldSource(_poolKey.currency0),
             _getMaxWithdrawFromYieldSource(_poolKey.currency1)
         );

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -100,8 +100,8 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /// @dev The offset of the just-in-time position upper tick within {REHYPOTHECATION_HOOK_SLOT}.
     uint256 private constant TICK_UPPER_OFFSET = 1;
 
-    /// @dev The offset of the swap-cycle lock flag within {REHYPOTHECATION_HOOK_SLOT}.
-    uint256 private constant SWAP_CYCLE_OFFSET = 2;
+    /// @dev The offset of the JIT lock flag within {REHYPOTHECATION_HOOK_SLOT}.
+    uint256 private constant JIT_LOCK_OFFSET = 2;
 
     /// @dev Error thrown when trying to initialize a pool that has already been initialized.
     error AlreadyInitialized();
@@ -130,9 +130,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /// @dev Error thrown when a seed would mint fewer than the minimum safe initial `shares`, given `minShares`.
     error InsufficientSeed(uint256 shares, uint256 minShares);
 
-    /// @dev Error thrown when a liquidity operation and a swap cycle would overlap, to prevent reentrancy
-    /// across the just-in-time settlement.
-    error Locked();
+    /// @dev Error thrown when a liquidity operation and the just-in-time settlement would overlap,
+    /// to prevent reentrancy across the JIT lock.
+    error JITLocked();
 
     /**
      * @dev Emitted when a `sender` adds rehypothecated `shares` to the `poolKey` pool,
@@ -162,21 +162,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * should not be modified so that it can safely be used across the hook's lifecycle.
      * Note that the hook supports only one pool key.
      *
-     * WARNING: The first initialization permanently binds the hook to the pool it observes, and pool
-     * initialization is permissionless. A third party can front-run it and bind the hook to an unintended pool.
-     * Consider initializing the pool atomically with the hook's deployment. To reject an unexpected key on-chain,
-     * override this function:
-     *
-     * ```solidity
-     * function _beforeInitialize(address sender, PoolKey calldata key, uint160 sqrtPriceX96)
-     *     internal
-     *     override
-     *     returns (bytes4)
-     * {
-     *     if (key.fee != EXPECTED_FEE) revert WrongPool();
-     *     return super._beforeInitialize(sender, key, sqrtPriceX96);
-     * }
-     * ```
+     * WARNING: Pool initialization is permissionless and permanently binds the hook to the first key it sees,
+     * so a third party can front-run it with an unintended pool. Initialize the pool atomically with the hook's
+     * deployment, or override this function to reject an unexpected key.
      */
     function _beforeInitialize(address, PoolKey calldata key, uint160) internal virtual override returns (bytes4) {
         if (address(_poolKey.hooks) != address(0)) revert AlreadyInitialized();
@@ -187,26 +175,22 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /**
      * @dev Seeds the pool with its first liquidity, depositing `amount0` of `currency0` and `amount1` of
      * `currency1` into the yield sources and minting `sqrt(amount0 * amount1)` shares to the caller, in a
-     * UniswapV2 like fashion. The deposited amounts set the pool's initial ratio.
+     * UniswapV2 like fashion. The deposited amounts set the ratio at which {addReHypothecatedLiquidity}
+     * prices every later addition.
      *
      * Callable permissionlessly whenever the pool has no outstanding shares: at genesis, or to revive the pool
-     * after a full withdrawal (since {addReHypothecatedLiquidity} reverts once the supply is zero). Subsequent
-     * liquidity is added through {addReHypothecatedLiquidity}, which prices shares proportionally to the seeded balances.
-     *
-     * The minted shares must be at least `100 * 10 ** _decimalsOffset()`, so the supply dominates the
-     * virtual-shares offset used in {_shareToAmount} and the share price cannot be meaningfully inflated.
+     * after a full withdrawal. The minted shares must be at least `100 * 10 ** _decimalsOffset()`, so the supply
+     * dominates the virtual-shares offset used in {_shareToAmount} and the share price cannot be inflated.
      *
      * Returns the `shares` minted and a balance `delta` representing the assets deposited into the hook.
      *
      * NOTE: The amounts should be provided close to the pool's current price, otherwise part of the seeded
      * liquidity may sit idle until swaps rebalance it. See {_getLiquidityToUse}.
      *
-     * WARNING: The deposited amounts set the ratio at which every later liquidity addition is priced, and
-     * seeding is permissionless. A third party can front-run the intended seed with a heavily skewed ratio.
-     * Since {_getLiquidityToUse} is bounded by the scarcer side, the hook is then left with negligible usable
-     * liquidity and cannot serve swaps. Deposited assets stay redeemable, and seeding reopens once the supply
-     * returns to zero. Consider seeding atomically with pool initialization, or overriding this function to
-     * restrict the caller.
+     * WARNING: A third party can front-run the intended seed with a heavily skewed ratio. Since
+     * {_getLiquidityToUse} is bounded by the scarcer side, the hook is then left with negligible usable liquidity
+     * and cannot serve swaps. Deposited assets stay redeemable, and seeding reopens once the supply returns to
+     * zero. Consider seeding atomically with pool initialization, or overriding this function to restrict the caller.
      *
      * Requirements:
      * - Pool must be initialized
@@ -222,7 +206,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         returns (uint256 shares, BalanceDelta delta)
     {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
-        if (_inSwapCycle()) revert Locked();
+        if (_isJITLocked()) revert JITLocked();
         if (totalSupply() != 0) revert AlreadySeeded();
 
         shares = Math.sqrt(amount0 * amount1);
@@ -265,7 +249,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         returns (BalanceDelta delta)
     {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
-        if (_inSwapCycle()) revert Locked();
+        if (_isJITLocked()) revert JITLocked();
         if (totalSupply() == 0) revert NotSeeded();
         if (shares == 0) revert ZeroShares();
 
@@ -300,7 +284,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      */
     function removeReHypothecatedLiquidity(uint256 shares) public virtual nonReentrant returns (BalanceDelta delta) {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
-        if (_inSwapCycle()) revert Locked();
+        if (_isJITLocked()) revert JITLocked();
         if (shares == 0) revert ZeroShares();
 
         (uint256 amount0, uint256 amount1) = previewRedeem(shares);
@@ -340,10 +324,10 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {
-        // Lock the swap cycle: block liquidity operations from reentering mid-settlement, and block a swap
-        // from running inside a liquidity operation or another swap cycle. Cleared at the end of `_afterSwap`.
-        if (_reentrancyGuardEntered() || _inSwapCycle()) revert Locked();
-        _setSwapCycle(true);
+        // Take the JIT lock: block liquidity operations from reentering mid-settlement, and block a swap
+        // from running inside a liquidity operation or another swap. Released at the end of `_afterSwap`.
+        if (_reentrancyGuardEntered() || _isJITLocked()) revert JITLocked();
+        _setJITLocked(true);
 
         // Snapshot the position's tick bounds so `afterSwap` removes exactly what is added here.
         _snapshotActiveTicks();
@@ -383,8 +367,8 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
             _resolveHookDelta(key.currency1);
         }
 
-        // Unlock the swap cycle once settlement (and its external yield-source calls) is complete.
-        _setSwapCycle(false);
+        // Release the JIT lock once settlement (and its external yield-source calls) is complete.
+        _setJITLocked(false);
 
         return (this.afterSwap.selector, 0);
     }
@@ -550,14 +534,14 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         return int24(REHYPOTHECATION_HOOK_SLOT.offset(TICK_UPPER_OFFSET).asInt256().tload());
     }
 
-    /// @dev Sets whether a swap cycle (`beforeSwap` through `afterSwap`) is currently in progress.
-    function _setSwapCycle(bool active) private {
-        REHYPOTHECATION_HOOK_SLOT.offset(SWAP_CYCLE_OFFSET).asBoolean().tstore(active);
+    /// @dev Sets whether the JIT lock (`beforeSwap` through `afterSwap`) is held.
+    function _setJITLocked(bool active) private {
+        REHYPOTHECATION_HOOK_SLOT.offset(JIT_LOCK_OFFSET).asBoolean().tstore(active);
     }
 
-    /// @dev Whether a swap cycle is currently in progress.
-    function _inSwapCycle() private view returns (bool) {
-        return REHYPOTHECATION_HOOK_SLOT.offset(SWAP_CYCLE_OFFSET).asBoolean().tload();
+    /// @dev Whether the JIT lock is currently held.
+    function _isJITLocked() private view returns (bool) {
+        return REHYPOTHECATION_HOOK_SLOT.offset(JIT_LOCK_OFFSET).asBoolean().tload();
     }
 
     /**

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -162,24 +162,27 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * should not be modified so that it can safely be used across the hook's lifecycle.
      * Note that the hook supports only one pool key.
      *
-     * WARNING: The first initialization permanently binds the hook to the pool it observes. Since pool
-     * initialization is permissionless, a third party could front-run and bind the hook to an unintended pool.
-     * Deployers should initialize the pool atomically with the hook's deployment to avoid this, and may
-     * override {_validatePoolKey} to enforce the expected pool key.
+     * WARNING: The first initialization permanently binds the hook to the pool it observes, and pool
+     * initialization is permissionless. A third party can front-run it and bind the hook to an unintended pool.
+     * Consider initializing the pool atomically with the hook's deployment. To reject an unexpected key on-chain,
+     * override this function:
+     *
+     * ```solidity
+     * function _beforeInitialize(address sender, PoolKey calldata key, uint160 sqrtPriceX96)
+     *     internal
+     *     override
+     *     returns (bytes4)
+     * {
+     *     if (key.fee != EXPECTED_FEE) revert WrongPool();
+     *     return super._beforeInitialize(sender, key, sqrtPriceX96);
+     * }
+     * ```
      */
     function _beforeInitialize(address, PoolKey calldata key, uint160) internal virtual override returns (bytes4) {
         if (address(_poolKey.hooks) != address(0)) revert AlreadyInitialized();
-        _validatePoolKey(key);
         _poolKey = key;
         return this.beforeInitialize.selector;
     }
-
-    /**
-     * @dev Validates the `key` the hook is about to bind to on first initialization. Defaults to accepting any
-     * key; override to restrict the hook to an expected pool (e.g. specific currencies, fee or tick spacing)
-     * and defend against front-run binding. See {_beforeInitialize}.
-     */
-    function _validatePoolKey(PoolKey calldata key) internal view virtual {}
 
     /**
      * @dev Seeds the pool with its first liquidity, depositing `amount0` of `currency0` and `amount1` of
@@ -197,6 +200,13 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      *
      * NOTE: The amounts should be provided close to the pool's current price, otherwise part of the seeded
      * liquidity may sit idle until swaps rebalance it. See {_getLiquidityToUse}.
+     *
+     * WARNING: The deposited amounts set the ratio at which every later liquidity addition is priced, and
+     * seeding is permissionless. A third party can front-run the intended seed with a heavily skewed ratio.
+     * Since {_getLiquidityToUse} is bounded by the scarcer side, the hook is then left with negligible usable
+     * liquidity and cannot serve swaps. Deposited assets stay redeemable, and seeding reopens once the supply
+     * returns to zero. Consider seeding atomically with pool initialization, or overriding this function to
+     * restrict the caller.
      *
      * Requirements:
      * - Pool must be initialized

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -439,8 +439,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /**
      * @dev Calculates the `liquidity` to be provided just-in-time for incoming swaps.
      *
-     * By default, returns the maximum liquidity that can be provided given the current balances
-     * of the hook in the yield sources.
+     * By default, returns the maximum liquidity that can be provided given the balances the hook can
+     * currently withdraw from the yield sources (see {_getMaxWithdrawFromYieldSource}), so the position
+     * removed in `afterSwap` never exceeds what the yield sources can return in the same transaction.
      *
      * Since the internal pool price (ratio of currency0 to currency1) must be preserved for providing
      * liquidity to the single hook-owned position range, not necessarily all the assets in the yield
@@ -460,8 +461,8 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
             currentSqrtPriceX96,
             TickMath.getSqrtPriceAtTick(getTickLower()),
             TickMath.getSqrtPriceAtTick(getTickUpper()),
-            _getAmountInYieldSource(_poolKey.currency0),
-            _getAmountInYieldSource(_poolKey.currency1)
+            _getMaxWithdrawFromYieldSource(_poolKey.currency0),
+            _getMaxWithdrawFromYieldSource(_poolKey.currency1)
         );
     }
 
@@ -565,6 +566,20 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      *  ERC-4626 Vaults, or any custom DeFi protocol interface, optionally handling native currency.
      */
     function _getAmountInYieldSource(Currency currency) internal view virtual returns (uint256 amount);
+
+    /**
+     * @dev Returns the maximum `amount` of `currency` that can currently be withdrawn from its yield source.
+     *
+     * Used to size the just-in-time liquidity provided during swaps, so the hook never provisions more than it
+     * can withdraw back in the same transaction. Share pricing instead uses {_getAmountInYieldSource}, the full
+     * reported balance.
+     *
+     * Defaults to {_getAmountInYieldSource}. Override for yield sources whose immediately-withdrawable amount can
+     * be below the reported balance, such as ERC-4626 `maxWithdraw`, or capped, gated or fee-charging sources.
+     */
+    function _getMaxWithdrawFromYieldSource(Currency currency) internal view virtual returns (uint256) {
+        return _getAmountInYieldSource(currency);
+    }
 
     /**
      * Set the hooks permissions, specifically `beforeInitialize`, `beforeSwap`, `afterSwap`.

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -49,6 +49,10 @@ import {CurrencySettler} from "../utils/CurrencySettler.sol";
  * NOTE: Since the hook owns the single liquidity position, it is possible to perform "leveraged liquidity" strategies,
  * which would give better pricing to swappers at the cost of the profitability of LP's and increased risks. See {_getLiquidityToUse}
  *
+ * NOTE: A pool must be seeded once via {seedLiquidity} before liquidity can be added through {addReHypothecatedLiquidity}.
+ * The seed sets the initial ratio and mints the first shares as `sqrt(amount0 * amount1)`, in a UniswapV2 like fashion.
+ * From there, a share represents a proportional claim over the hook's balances in the yield sources.
+ *
  * WARNING: As the assets are rehypothecated into external yield sources, there is direct exposure to their risks,
  * such as variations in the yield rates, rebalances, impermanent loss, and other risks associated.
  *
@@ -96,6 +100,15 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /// @dev Error thrown when a third party attempts to provide or remove liquidity directly on the pool.
     error LiquidityNotAllowed();
 
+    /// @dev Error thrown when adding liquidity before the pool has been seeded.
+    error NotSeeded();
+
+    /// @dev Error thrown when seeding a pool that has already been seeded.
+    error AlreadySeeded();
+
+    /// @dev Error thrown when a seed would mint fewer than the minimum safe initial `shares`, given `minShares`.
+    error InsufficientSeed(uint256 shares, uint256 minShares);
+
     /**
      * @dev Emitted when a `sender` adds rehypothecated `shares` to the `poolKey` pool,
      *  transferring `amount0` of `currency0` and `amount1` of `currency1` to the hook.
@@ -131,6 +144,55 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     }
 
     /**
+     * @dev Seeds the pool with its first liquidity, depositing `amount0` of `currency0` and `amount1` of
+     * `currency1` into the yield sources and minting `sqrt(amount0 * amount1)` shares to the caller, in a
+     * UniswapV2 like fashion. The deposited amounts set the pool's initial ratio.
+     *
+     * Callable once, permissionlessly, while no shares have been minted yet. Subsequent liquidity is added
+     * through {addReHypothecatedLiquidity}, which prices shares proportionally to the seeded balances.
+     *
+     * The minted shares must be at least `100 * 10 ** _decimalsOffset()`, so the supply dominates the
+     * virtual-shares offset used in {_shareToAmount} and the share price cannot be meaningfully inflated.
+     *
+     * Returns the `shares` minted and a balance `delta` representing the assets deposited into the hook.
+     *
+     * NOTE: The amounts should be provided close to the pool's current price, otherwise part of the seeded
+     * liquidity may sit idle until swaps rebalance it. See {_getLiquidityToUse}.
+     *
+     * Requirements:
+     * - Pool must be initialized
+     * - Pool must not have been seeded yet
+     * - Resulting shares must be at least `100 * 10 ** _decimalsOffset()`
+     * - Sender must have approved the hook to spend the required tokens
+     */
+    function seedLiquidity(uint256 amount0, uint256 amount1)
+        public
+        payable
+        virtual
+        nonReentrant
+        returns (uint256 shares, BalanceDelta delta)
+    {
+        if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
+        if (totalSupply() != 0) revert AlreadySeeded();
+
+        shares = Math.sqrt(amount0 * amount1);
+        uint256 minShares = 100 * 10 ** uint256(_decimalsOffset());
+        if (shares < minShares) revert InsufficientSeed(shares, minShares);
+
+        _transferFromSenderToHook(_poolKey.currency0, amount0, msg.sender);
+        _transferFromSenderToHook(_poolKey.currency1, amount1, msg.sender);
+
+        _depositToYieldSource(_poolKey.currency0, amount0);
+        _depositToYieldSource(_poolKey.currency1, amount1);
+
+        _mint(msg.sender, shares);
+
+        emit ReHypothecatedLiquidityAdded(msg.sender, _poolKey, shares, amount0, amount1);
+
+        return (shares, toBalanceDelta(-int256(amount0).toInt128(), -int256(amount1).toInt128()));
+    }
+
+    /**
      * @dev Adds rehypothecated liquidity to their corresponding yield sources and mints `shares` to the `receiver`.
      *
      * Liquidity is added in the ratio determined by the hook's existing balances in yield sources.
@@ -141,6 +203,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      *
      * Requirements:
      * - Pool must be initialized
+     * - Pool must have been seeded (see {seedLiquidity})
      * - Sender must have sufficient token balances
      * - Sender must have approved the hook to spend the required tokens
      */
@@ -152,6 +215,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         returns (BalanceDelta delta)
     {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
+        if (totalSupply() == 0) revert NotSeeded();
         if (shares == 0) revert ZeroShares();
 
         (uint256 amount0, uint256 amount1) = previewMint(shares);
@@ -325,10 +389,11 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     }
 
     /**
-     * @dev Calculates the amounts of currency0 and currency1 required for minting or redeeming a given amount of shares.
+     * @dev Calculates the amounts of currency0 and currency1 equivalent to a given amount of `shares`, as a
+     * proportional claim over the hook's balances in the yield sources, using the given rounding direction.
      *
-     * If the hook has not emitted shares yet, the initial mint/redeem ratio is determined by the internal pool price.
-     * Otherwise, it is determined by the ratio of the hook balances in the yield sources.
+     * Reverts with {NotSeeded} when no shares have been minted yet, since the pool has no defined ratio before
+     * {seedLiquidity}.
      */
     function _sharesToAmounts(uint256 shares, Math.Rounding rounding)
         internal
@@ -336,24 +401,17 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         virtual
         returns (uint256 amount0, uint256 amount1)
     {
-        // If the hook has not emitted shares yet, then consider `liquidity == shares`
-        if (totalSupply() == 0) {
-            (uint160 currentSqrtPriceX96,,,) = poolManager.getSlot0(_poolKey.toId());
-            return LiquidityAmounts.getAmountsForLiquidity(
-                currentSqrtPriceX96,
-                TickMath.getSqrtPriceAtTick(getTickLower()),
-                TickMath.getSqrtPriceAtTick(getTickUpper()),
-                shares.toUint128()
-            );
-        } else {
-            amount0 = _shareToAmount(shares, _poolKey.currency0, rounding);
-            amount1 = _shareToAmount(shares, _poolKey.currency1, rounding);
-        }
+        amount0 = _shareToAmount(shares, _poolKey.currency0, rounding);
+        amount1 = _shareToAmount(shares, _poolKey.currency1, rounding);
     }
 
     /**
-     * @dev Converts a given `shares` amount to the corresponding `currency` amount using
-     * the given rounding direction.
+     * @dev Converts a given `shares` amount to the corresponding `currency` amount, as its proportional claim
+     * over the hook's balance of `currency` in the yield source, using the given rounding direction.
+     *
+     * Uses an EIP-4626 like virtual offset (see {_decimalsOffset}) to defend the share price against inflation,
+     * so a share is worth `(balance + 1) / (totalSupply + 10 ** _decimalsOffset())` of the `currency` balance.
+     * Reverts with {NotSeeded} before the pool is seeded.
      */
     function _shareToAmount(uint256 shares, Currency currency, Math.Rounding rounding)
         internal
@@ -361,9 +419,21 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         virtual
         returns (uint256 amount)
     {
-        uint256 totalAmount = _getAmountInYieldSource(currency);
-        if (totalAmount == 0) return 0;
-        return shares.mulDiv(totalAmount, totalSupply(), rounding);
+        uint256 supply = totalSupply();
+        if (supply == 0) revert NotSeeded();
+        return shares.mulDiv(_getAmountInYieldSource(currency) + 1, supply + 10 ** uint256(_decimalsOffset()), rounding);
+    }
+
+    /**
+     * @dev Returns the decimal offset used for the EIP-4626 like virtual shares that defend the share price
+     * against inflation. The initial supply minted by {seedLiquidity} is required to be at least
+     * `100 * 10 ** _decimalsOffset()`, keeping the maximum share price drift around 1%.
+     *
+     * Defaults to `6`, which suits most token pairs. Can be overridden to strengthen the defense with a higher
+     * offset, at the cost of a larger minimum seed, for example for high-decimal pairs.
+     */
+    function _decimalsOffset() internal view virtual returns (uint8) {
+        return 6;
     }
 
     /**

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -56,7 +56,8 @@ import {CurrencySettler} from "../utils/CurrencySettler.sol";
  * During `afterSwap`, the hook briefly generates token debts to the PoolManager even before users transfer their swap tokens.
  * As a consequence, the PoolManager singleton may lack sufficient reserves for illiquid tokens in the instants between the swap
  * executed and the posterior payment from the user, preventing swaps from being executed until the PoolManager accumulates enough tokens.
- * Altrough it is very unlikely to happen, it can be mitigated by maintaining some permanent pool liquidity alongside rehypothecated liquidity.
+ * Although it is very unlikely to happen, note that direct liquidity provision to the pool is disabled, so the hook is the sole
+ * liquidity provider for its pool.
  *
  * WARNING: Liquidity additions and removals may be affected by slippage. Users can protect against unexpected slippage
  * in general by verifying the amount received is as expected, using a wrapper that performs these checks.
@@ -91,6 +92,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
 
     /// @dev Error thrown when the refund fails.
     error RefundFailed();
+
+    /// @dev Error thrown when a third party attempts to provide or remove liquidity directly on the pool.
+    error LiquidityNotAllowed();
 
     /**
      * @dev Emitted when a `sender` adds rehypothecated `shares` to the `poolKey` pool,
@@ -271,6 +275,35 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
             _withdrawFromYieldSource(currency, (-currencyDelta).toUint256());
             currency.settle(poolManager, address(this), (-currencyDelta).toUint256(), false);
         }
+    }
+
+    /**
+     * @dev Blocks direct liquidity provision to the pool by third parties, so the hook remains the pool's sole
+     * liquidity provider. This prevents external positions from interfering with the hook's just-in-time liquidity,
+     * such as saturating the position's tick boundaries and reverting subsequent swaps.
+     *
+     * Note that the hook's own just-in-time liquidity provisioning is unaffected, since the `PoolManager` skips hook
+     * callbacks when the hook itself is modifying liquidity.
+     */
+    function _beforeAddLiquidity(address, PoolKey calldata, ModifyLiquidityParams calldata, bytes calldata)
+        internal
+        virtual
+        override
+        returns (bytes4)
+    {
+        revert LiquidityNotAllowed();
+    }
+
+    /**
+     * @dev Blocks direct liquidity removal from the pool by third parties. See {_beforeAddLiquidity}.
+     */
+    function _beforeRemoveLiquidity(address, PoolKey calldata, ModifyLiquidityParams calldata, bytes calldata)
+        internal
+        virtual
+        override
+        returns (bytes4)
+    {
+        revert LiquidityNotAllowed();
     }
 
     /**
@@ -471,9 +504,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         return Hooks.Permissions({
             beforeInitialize: true,
             afterInitialize: false,
-            beforeAddLiquidity: false,
+            beforeAddLiquidity: true,
             afterAddLiquidity: false,
-            beforeRemoveLiquidity: false,
+            beforeRemoveLiquidity: true,
             afterRemoveLiquidity: false,
             beforeSwap: true,
             afterSwap: true,

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -305,8 +305,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {
-        // Snapshot the position's tick bounds so `afterSwap` removes exactly what is added here, even if the
-        // tick getters are overridden to depend on mutable pool state that the swap then moves.
+        // Snapshot the position's tick bounds so `afterSwap` removes exactly what is added here.
         _snapshotActiveTicks();
 
         // Get the liquidity to be used from the amounts currently deposited in the yield sources

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -49,8 +49,9 @@ import {CurrencySettler} from "../utils/CurrencySettler.sol";
  * NOTE: Since the hook owns the single liquidity position, it is possible to perform "leveraged liquidity" strategies,
  * which would give better pricing to swappers at the cost of the profitability of LP's and increased risks. See {_getLiquidityToUse}
  *
- * NOTE: A pool must be seeded once via {seedLiquidity} before liquidity can be added through {addReHypothecatedLiquidity}.
- * The seed sets the initial ratio and mints the first shares as `sqrt(amount0 * amount1)`, in a UniswapV2 like fashion.
+ * NOTE: A pool must be seeded via {seedLiquidity} before liquidity can be added through {addReHypothecatedLiquidity}.
+ * Seeding is allowed whenever the pool has no outstanding shares, i.e. at genesis or to revive the pool after a full
+ * withdrawal. The seed sets the ratio and mints shares as `sqrt(amount0 * amount1)`, in a UniswapV2 like fashion.
  * From there, a share represents a proportional claim over the hook's balances in the yield sources.
  *
  * WARNING: As the assets are rehypothecated into external yield sources, there is direct exposure to their risks,
@@ -103,7 +104,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /// @dev Error thrown when adding liquidity before the pool has been seeded.
     error NotSeeded();
 
-    /// @dev Error thrown when seeding a pool that has already been seeded.
+    /// @dev Error thrown when seeding a pool that still has outstanding shares.
     error AlreadySeeded();
 
     /// @dev Error thrown when a seed would mint fewer than the minimum safe initial `shares`, given `minShares`.
@@ -148,8 +149,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * `currency1` into the yield sources and minting `sqrt(amount0 * amount1)` shares to the caller, in a
      * UniswapV2 like fashion. The deposited amounts set the pool's initial ratio.
      *
-     * Callable once, permissionlessly, while no shares have been minted yet. Subsequent liquidity is added
-     * through {addReHypothecatedLiquidity}, which prices shares proportionally to the seeded balances.
+     * Callable permissionlessly whenever the pool has no outstanding shares: at genesis, or to revive the pool
+     * after a full withdrawal (since {addReHypothecatedLiquidity} reverts once the supply is zero). Subsequent
+     * liquidity is added through {addReHypothecatedLiquidity}, which prices shares proportionally to the seeded balances.
      *
      * The minted shares must be at least `100 * 10 ** _decimalsOffset()`, so the supply dominates the
      * virtual-shares offset used in {_shareToAmount} and the share price cannot be meaningfully inflated.
@@ -161,7 +163,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      *
      * Requirements:
      * - Pool must be initialized
-     * - Pool must not have been seeded yet
+     * - Pool must have no outstanding shares (`totalSupply() == 0`)
      * - Resulting shares must be at least `100 * 10 ** _decimalsOffset()`
      * - Sender must have approved the hook to spend the required tokens
      */

--- a/src/mocks/general/ReHypothecationERC4626Mock.sol
+++ b/src/mocks/general/ReHypothecationERC4626Mock.sol
@@ -87,6 +87,11 @@ contract ReHypothecationERC4626Mock is ReHypothecationHook {
         return yieldSource.convertToAssets(yieldSourceShares);
     }
 
+    /// @inheritdoc ReHypothecationHook
+    function _getMaxWithdrawFromYieldSource(Currency currency) internal view virtual override returns (uint256) {
+        return IERC4626(getCurrencyYieldSource(currency)).maxWithdraw(address(this));
+    }
+
     /// @dev Override to disable native currency, which is not supported by ERC-4626 yield sources.
     receive() external payable override {
         revert UnsupportedCurrency();
@@ -95,6 +100,16 @@ contract ReHypothecationERC4626Mock is ReHypothecationHook {
     /// @dev Exposed internal function for testing
     function getAmountInYieldSource(Currency currency) public view returns (uint256) {
         return _getAmountInYieldSource(currency);
+    }
+
+    /// @dev Exposed internal function for testing
+    function getMaxWithdrawFromYieldSource(Currency currency) public view returns (uint256) {
+        return _getMaxWithdrawFromYieldSource(currency);
+    }
+
+    /// @dev Exposed internal function for testing
+    function getLiquidityToUse() public view returns (uint256) {
+        return _getLiquidityToUse();
     }
 
     /// @dev Exposed internal function for testing

--- a/src/mocks/general/ReHypothecationERC4626Mock.sol
+++ b/src/mocks/general/ReHypothecationERC4626Mock.sol
@@ -50,6 +50,7 @@ contract ReHypothecationERC4626Mock is ReHypothecationHook {
     /// @dev Override to disable native currency, which is not supported by ERC-4626 yield sources.
     function _beforeInitialize(address sender, PoolKey calldata key, uint160 sqrtPriceX96)
         internal
+        virtual
         override
         returns (bytes4)
     {

--- a/src/mocks/general/ReHypothecationERC4626Mock.sol
+++ b/src/mocks/general/ReHypothecationERC4626Mock.sol
@@ -110,7 +110,7 @@ contract ReHypothecationERC4626Mock is ReHypothecationHook {
 
     /// @dev Exposed internal function for testing
     function getLiquidityToUse() public view returns (uint256) {
-        return _getLiquidityToUse();
+        return _getLiquidityToUse(getTickLower(), getTickUpper());
     }
 
     /// @dev Exposed internal function for testing

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -14,6 +14,8 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {CustomRevert} from "@uniswap/v4-core/src/libraries/CustomRevert.sol";
+import {LiquidityAmounts} from "@uniswap/v4-core/test/utils/LiquidityAmounts.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
 // Internal imports
 import {
     ReHypothecationERC4626Mock,
@@ -40,6 +42,13 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     address lp2 = makeAddr("lp2");
 
     uint24 fee = 1000; // 0.1%
+
+    /// @dev Amount used to seed each currency; at price 1:1 this mints `sqrt(SEED * SEED) == SEED` shares.
+    uint256 constant SEED = 1e18;
+    uint256 constant SEED_SHARES = SEED;
+
+    /// @dev Absolute tolerance covering the EIP-4626 style virtual offset and rounding (offset is 1e6).
+    uint256 constant TOL = 1e9;
 
     function setUp() public {
         deployFreshManagerAndRouters();
@@ -98,6 +107,16 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
             }
             vm.stopPrank();
         }
+    }
+
+    /// @dev Seeds the pool (from `who`) with `SEED` of each currency, minting `SEED_SHARES` shares.
+    function _seedBy(address who) internal returns (uint256 shares) {
+        vm.prank(who);
+        (shares,) = hook.seedLiquidity(SEED, SEED);
+    }
+
+    function _seed() internal returns (uint256 shares) {
+        (shares,) = hook.seedLiquidity(SEED, SEED);
     }
 
     // -- INITIALIZING -- //
@@ -169,6 +188,61 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         modifyPoolLiquidity(key, tickLower, tickUpper, -int256(1e18), 0);
     }
 
+    // -- SEEDING -- //
+
+    function test_seed_uninitialized_reverts() public {
+        uint160 hookFlags = uint160(
+            Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG
+                | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG
+        );
+        ReHypothecationERC4626Mock newHook = ReHypothecationERC4626Mock(
+            payable(address(hookFlags + 0x10000000000000000000000000000000)) // generate a different address
+        );
+        deployCodeTo(
+            "src/mocks/general/ReHypothecationERC4626Mock.sol:ReHypothecationERC4626Mock",
+            abi.encode(address(manager), address(yieldSource0), address(yieldSource1)),
+            address(newHook)
+        );
+        vm.expectRevert(ReHypothecationHook.NotInitialized.selector);
+        newHook.seedLiquidity(SEED, SEED);
+    }
+
+    function test_seed_alreadySeeded_reverts() public {
+        _seed();
+        vm.expectRevert(ReHypothecationHook.AlreadySeeded.selector);
+        hook.seedLiquidity(SEED, SEED);
+    }
+
+    function test_seed_belowFloor_reverts() public {
+        // sqrt(1000 * 1000) == 1000, below the 100 * 10**6 floor.
+        vm.expectRevert(abi.encodeWithSelector(ReHypothecationHook.InsufficientSeed.selector, 1000, 100_000_000));
+        hook.seedLiquidity(1000, 1000);
+    }
+
+    function test_seed_mintsSqrtShares() public {
+        uint256 amount0 = 4e18;
+        uint256 amount1 = 1e18;
+
+        uint256 lpAmount0Before = IERC20(Currency.unwrap(currency0)).balanceOf(address(this));
+        uint256 lpAmount1Before = IERC20(Currency.unwrap(currency1)).balanceOf(address(this));
+
+        (uint256 shares, BalanceDelta delta) = hook.seedLiquidity(amount0, amount1);
+
+        // shares are the geometric mean of the seeded amounts
+        assertEq(shares, Math.sqrt(amount0 * amount1), "shares != sqrt(amount0 * amount1)");
+        assertEq(shares, 2e18, "shares != 2e18");
+        assertEq(hook.balanceOf(address(this)), shares, "balance != shares");
+        assertEq(hook.totalSupply(), shares, "totalSupply != shares");
+
+        // the seeded amounts were pulled and deposited into the yield sources
+        assertEq((-delta.amount0()).toUint256(), amount0, "delta.amount0() != amount0");
+        assertEq((-delta.amount1()).toUint256(), amount1, "delta.amount1() != amount1");
+        assertEq(lpAmount0Before - IERC20(Currency.unwrap(currency0)).balanceOf(address(this)), amount0);
+        assertEq(lpAmount1Before - IERC20(Currency.unwrap(currency1)).balanceOf(address(this)), amount1);
+        assertEq(hook.getAmountInYieldSource(currency0), amount0, "yieldSource0 != amount0");
+        assertEq(hook.getAmountInYieldSource(currency1), amount1, "yieldSource1 != amount1");
+    }
+
     // -- ADDING -- //
 
     function test_add_uninitialized_reverts() public {
@@ -188,13 +262,22 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         newHook.addReHypothecatedLiquidity(1e15);
     }
 
+    function test_add_notSeeded_reverts() public {
+        vm.expectRevert(ReHypothecationHook.NotSeeded.selector);
+        hook.addReHypothecatedLiquidity(1e15);
+    }
+
     function test_add_zero_reverts() public {
+        _seed();
         vm.expectRevert(ReHypothecationHook.ZeroShares.selector);
         hook.addReHypothecatedLiquidity(0);
     }
 
     function testFuzz_add_singleLP(uint128 shares) public {
         shares = uint128(bound(shares, 1e12, 1e20));
+
+        // Seed the pool from a different LP so the tested `add` runs against a live pool.
+        _seedBy(lp1);
 
         uint256 lpAmount0Before = IERC20(Currency.unwrap(currency0)).balanceOf(address(this));
         uint256 lpAmount1Before = IERC20(Currency.unwrap(currency1)).balanceOf(address(this));
@@ -229,13 +312,15 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
             "amount1InYieldSource1After != amount1InYieldSource1Before + amount1"
         );
 
-        uint256 obtainedShares = hook.balanceOf(address(this));
-        assertEq(obtainedShares, hook.totalSupply(), "obtained shares != total supply");
+        assertEq(hook.balanceOf(address(this)), shares, "obtained shares != shares");
     }
 
     function test_add_multipleLP() public {
         uint128 shareslp1 = 1e18;
         uint128 shareslp2 = 1e18;
+
+        // lp1 seeds the pool (minting SEED_SHARES), then adds like lp2.
+        _seedBy(lp1);
 
         vm.prank(lp1);
         BalanceDelta addDeltalp1 = hook.addReHypothecatedLiquidity(shareslp1);
@@ -243,20 +328,23 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         vm.prank(lp2);
         BalanceDelta addDeltalp2 = hook.addReHypothecatedLiquidity(shareslp2);
 
-        // both must have paid the same amount of assets
-        assertEq(addDeltalp1, addDeltalp2);
+        // both add the same shares against the same state, so pay the same amount of assets
+        assertApproxEqAbs(addDeltalp1, addDeltalp2, TOL);
 
-        // both must have received the same amount of assets
-        assertEq(hook.balanceOf(lp1), hook.balanceOf(lp2));
+        // lp1 additionally holds the seed shares
+        assertEq(hook.balanceOf(lp1), SEED_SHARES + shareslp1);
+        assertEq(hook.balanceOf(lp2), shareslp2);
 
-        // total supply should be the sum of the shares
-        assertEq(hook.totalSupply(), shareslp1 + shareslp2);
+        // total supply should be the sum of the seed and both adds
+        assertEq(hook.totalSupply(), SEED_SHARES + shareslp1 + shareslp2);
     }
 
     function test_add_swap_add_multipleLP() public {
         // both lps want equal amount of shares
         uint128 shareslp1 = 1e18;
         uint128 shareslp2 = 1e18;
+
+        _seed();
 
         vm.prank(lp1);
         BalanceDelta addDeltalp1 = hook.addReHypothecatedLiquidity(shareslp1);
@@ -275,58 +363,75 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         assertGt(-addDeltalp2.amount0(), -addDeltalp1.amount0());
         assertGt(-addDeltalp2.amount1(), -addDeltalp1.amount1());
 
-        // total supply should be the sum of the shares
-        assertEq(hook.totalSupply(), shareslp1 + shareslp2);
+        // total supply should be the sum of the seed and both adds
+        assertEq(hook.totalSupply(), SEED_SHARES + shareslp1 + shareslp2);
     }
 
     function test_add_yieldsGrowth_add_multipleLP() public {
         uint128 shareslp1 = 1e18;
         uint128 shareslp2 = 1e18;
 
-        vm.prank(lp1);
-        BalanceDelta addDeltalp1 = hook.addReHypothecatedLiquidity(shareslp1);
+        // lp1 seeds the pool, so at this point pile == supply == SEED_SHARES.
+        _seedBy(lp1);
+
+        BalanceDelta addDeltalp1;
+        {
+            uint256 amount0Before = hook.getAmountInYieldSource(currency0);
+            uint256 amount1Before = hook.getAmountInYieldSource(currency1);
+            vm.prank(lp2);
+            addDeltalp1 = hook.addReHypothecatedLiquidity(shareslp1);
+            // capture how much lp1-equivalent (lp2) paid against the seeded pile
+            amount0Before;
+            amount1Before;
+        }
 
         uint256 amount0InYieldSource = hook.getAmountInYieldSource(currency0);
         uint256 amount1InYieldSource = hook.getAmountInYieldSource(currency1);
 
-        // yield1 grows by 10%
+        // yield0 grows by 10%
         currency0.transfer(address(yieldSource0), amount0InYieldSource * 10 / 100);
-        // yield2 grows by 20%
+        // yield1 grows by 20%
         currency1.transfer(address(yieldSource1), amount1InYieldSource * 20 / 100);
 
+        vm.prank(lp2);
         BalanceDelta addDeltalp2 = hook.addReHypothecatedLiquidity(shareslp2);
 
-        // in order to obtain the same shares as lp1, lp2 must deposit 10% more currency0 and 20% more currency1
-        assertApproxEqAbs(-addDeltalp2.amount0(), -addDeltalp1.amount0() * 110 / 100, 1);
-        assertApproxEqAbs(-addDeltalp2.amount1(), -addDeltalp1.amount1() * 120 / 100, 1);
+        // in order to obtain the same shares as the first add, the second add pays 10% more currency0
+        // and 20% more currency1
+        assertApproxEqAbs(-addDeltalp2.amount0(), -addDeltalp1.amount0() * 110 / 100, TOL);
+        assertApproxEqAbs(-addDeltalp2.amount1(), -addDeltalp1.amount1() * 120 / 100, TOL);
 
-        // total supply should be the sum of the shares
-        assertEq(hook.totalSupply(), shareslp1 + shareslp2);
+        // total supply should be the sum of the seed and both adds
+        assertEq(hook.totalSupply(), SEED_SHARES + shareslp1 + shareslp2);
     }
 
     function test_add_yieldsDecay_add_multipleLP() public {
         uint128 shareslp1 = 1e18;
         uint128 shareslp2 = 1e18;
 
-        vm.prank(lp1);
+        _seedBy(lp1);
+
+        vm.prank(lp2);
         BalanceDelta addDeltalp1 = hook.addReHypothecatedLiquidity(shareslp1);
 
         uint256 amount0InYieldSource = hook.getAmountInYieldSource(currency0);
         uint256 amount1InYieldSource = hook.getAmountInYieldSource(currency1);
 
-        // yield1 decays by 10%
+        // yield0 decays by 10%
         hook.burnYieldSourcesBalance(currency0, amount0InYieldSource * 10 / 100);
-        // yield2 decays by 20%
+        // yield1 decays by 20%
         hook.burnYieldSourcesBalance(currency1, amount1InYieldSource * 20 / 100);
 
+        vm.prank(lp2);
         BalanceDelta addDeltalp2 = hook.addReHypothecatedLiquidity(shareslp2);
 
-        // in order to obtain the same shares as lp1, lp2 must deposit 10% less currency0 and 20% less currency1
-        assertApproxEqAbs(-addDeltalp2.amount0(), -addDeltalp1.amount0() * 90 / 100, 1);
-        assertApproxEqAbs(-addDeltalp2.amount1(), -addDeltalp1.amount1() * 80 / 100, 1);
+        // in order to obtain the same shares as the first add, the second add pays 10% less currency0
+        // and 20% less currency1
+        assertApproxEqAbs(-addDeltalp2.amount0(), -addDeltalp1.amount0() * 90 / 100, TOL);
+        assertApproxEqAbs(-addDeltalp2.amount1(), -addDeltalp1.amount1() * 80 / 100, TOL);
 
-        // total supply should be the sum of the shares
-        assertEq(hook.totalSupply(), shareslp1 + shareslp2);
+        // total supply should be the sum of the seed and both adds
+        assertEq(hook.totalSupply(), SEED_SHARES + shareslp1 + shareslp2);
     }
 
     // -- REMOVING -- //
@@ -356,7 +461,8 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     function testFuzz_remove_singleLP(uint128 shares) public {
         shares = uint128(bound(shares, 1e12, 1e20));
 
-        BalanceDelta addDelta = hook.addReHypothecatedLiquidity(shares);
+        // Seed such that the caller ends up holding exactly `shares` shares.
+        (, BalanceDelta addDelta) = hook.seedLiquidity(shares, shares);
 
         uint256 lpAmount0Before = IERC20(Currency.unwrap(currency0)).balanceOf(address(this));
         uint256 lpAmount1Before = IERC20(Currency.unwrap(currency1)).balanceOf(address(this));
@@ -368,11 +474,11 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
 
         BalanceDelta removeDelta = hook.removeReHypothecatedLiquidity(shares);
 
-        assertEq(-addDelta.amount0(), removeDelta.amount0());
-        assertEq(-addDelta.amount1(), removeDelta.amount1());
-
+        // withdrawn amount matches the previewed redeem, and is within a virtual-offset dust of the seeded amount
         assertEq(removeDelta.amount0().toUint256(), amount0, "Delta.amount0() != amount0");
         assertEq(removeDelta.amount1().toUint256(), amount1, "Delta.amount1() != amount1");
+        assertApproxEqAbs(-addDelta.amount0(), removeDelta.amount0(), TOL);
+        assertApproxEqAbs(-addDelta.amount1(), removeDelta.amount1(), TOL);
 
         uint256 lpAmount0After = IERC20(Currency.unwrap(currency0)).balanceOf(address(this));
         uint256 lpAmount1After = IERC20(Currency.unwrap(currency1)).balanceOf(address(this));
@@ -386,12 +492,12 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         assertEq(
             amount0InYieldSource0After,
             amount0InYieldSource0Before - amount0,
-            "amount0InYieldSource0After != amount0InYieldSource0Before + amount0"
+            "amount0InYieldSource0After != amount0InYieldSource0Before - amount0"
         );
         assertEq(
             amount1InYieldSource1After,
             amount1InYieldSource1Before - amount1,
-            "amount1InYieldSource1After != amount1InYieldSource1Before + amount1"
+            "amount1InYieldSource1After != amount1InYieldSource1Before - amount1"
         );
 
         assertEq(hook.balanceOf(address(this)), 0, "Held shares != 0");
@@ -399,21 +505,20 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     }
 
     function test_remove_multipleLP() public {
-        uint128 shareslp1 = 1e18;
         uint128 shareslp2 = 1e18;
 
-        vm.prank(lp1);
-        hook.addReHypothecatedLiquidity(shareslp1);
+        // lp1 seeds (holding SEED_SHARES), lp2 adds the same amount of shares.
+        _seedBy(lp1);
         vm.prank(lp2);
         hook.addReHypothecatedLiquidity(shareslp2);
 
         vm.prank(lp1);
-        BalanceDelta removeDeltalp1 = hook.removeReHypothecatedLiquidity(shareslp1);
+        BalanceDelta removeDeltalp1 = hook.removeReHypothecatedLiquidity(SEED_SHARES);
         vm.prank(lp2);
         BalanceDelta removeDeltalp2 = hook.removeReHypothecatedLiquidity(shareslp2);
 
-        // both must have removed the same amount of assets
-        assertEq(removeDeltalp1, removeDeltalp2);
+        // both held the same amount of shares, so remove approximately the same amount of assets
+        assertApproxEqAbs(removeDeltalp1, removeDeltalp2, TOL);
 
         // both must have burned their shares
         assertEq(hook.balanceOf(lp1), 0);
@@ -424,23 +529,21 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     }
 
     function test_swap_remove_remove_multipleLP() public {
-        uint128 shareslp1 = 1e18;
         uint128 shareslp2 = 1e18;
 
-        vm.prank(lp1);
-        hook.addReHypothecatedLiquidity(shareslp1);
+        _seedBy(lp1);
         vm.prank(lp2);
         hook.addReHypothecatedLiquidity(shareslp2);
 
         swap(key, true, 1e15, ZERO_BYTES);
 
         vm.prank(lp1);
-        BalanceDelta removeDeltalp1 = hook.removeReHypothecatedLiquidity(shareslp1);
+        BalanceDelta removeDeltalp1 = hook.removeReHypothecatedLiquidity(SEED_SHARES);
         vm.prank(lp2);
         BalanceDelta removeDeltalp2 = hook.removeReHypothecatedLiquidity(shareslp2);
 
-        // both must have removed the same amount of assets
-        assertApproxEqAbs(removeDeltalp1, removeDeltalp2, 1);
+        // both held the same amount of shares, so remove approximately the same amount of assets
+        assertApproxEqAbs(removeDeltalp1, removeDeltalp2, TOL);
 
         // both must have burned their shares
         assertEq(hook.balanceOf(lp1), 0);
@@ -451,16 +554,14 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     }
 
     function test_remove_swap_remove_multipleLP() public {
-        uint128 shareslp1 = 1e18;
         uint128 shareslp2 = 1e18;
 
-        vm.prank(lp1);
-        hook.addReHypothecatedLiquidity(shareslp1);
+        _seedBy(lp1);
         vm.prank(lp2);
         hook.addReHypothecatedLiquidity(shareslp2);
 
         vm.prank(lp1);
-        BalanceDelta removeDeltalp1 = hook.removeReHypothecatedLiquidity(shareslp1);
+        BalanceDelta removeDeltalp1 = hook.removeReHypothecatedLiquidity(SEED_SHARES);
 
         swap(key, true, 1e15, ZERO_BYTES);
         swap(key, false, 1e15 + 1e10, ZERO_BYTES);
@@ -468,7 +569,7 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         vm.prank(lp2);
         BalanceDelta removeDeltalp2 = hook.removeReHypothecatedLiquidity(shareslp2);
 
-        // lp2 must have removed more assets, since the fees from the swap belongs to him
+        // lp2 must have removed more assets, since the fees from the swap belong to it
         assertGt(removeDeltalp2.amount0(), removeDeltalp1.amount0());
         assertGt(removeDeltalp2.amount1(), removeDeltalp1.amount1());
 
@@ -481,33 +582,31 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     }
 
     function test_remove_yieldsGrowth_remove_multipleLP() public {
-        uint128 shareslp1 = 1e18;
         uint128 shareslp2 = 1e18;
 
-        vm.prank(lp1);
-        hook.addReHypothecatedLiquidity(shareslp1);
+        _seedBy(lp1);
         vm.prank(lp2);
         hook.addReHypothecatedLiquidity(shareslp2);
 
         // lp1 removes
         vm.prank(lp1);
-        BalanceDelta removeDeltalp1 = hook.removeReHypothecatedLiquidity(shareslp1);
+        BalanceDelta removeDeltalp1 = hook.removeReHypothecatedLiquidity(SEED_SHARES);
 
         uint256 amount0InYieldSource = hook.getAmountInYieldSource(currency0);
         uint256 amount1InYieldSource = hook.getAmountInYieldSource(currency1);
 
-        // yield1 grows by 10%
+        // yield0 grows by 10%
         currency0.transfer(address(yieldSource0), amount0InYieldSource * 10 / 100);
-        // yield2 grows by 20%
+        // yield1 grows by 20%
         currency1.transfer(address(yieldSource1), amount1InYieldSource * 20 / 100);
 
         // lp2 removes
         vm.prank(lp2);
         BalanceDelta removeDeltalp2 = hook.removeReHypothecatedLiquidity(shareslp2);
 
-        // lp2 must have removed more assets, since the fees from the yield growth belongs to him
-        assertApproxEqAbs(removeDeltalp2.amount0(), removeDeltalp1.amount0() * 110 / 100, 1);
-        assertApproxEqAbs(removeDeltalp2.amount1(), removeDeltalp1.amount1() * 120 / 100, 1);
+        // lp2 must have removed more assets, since the yield growth belongs to it
+        assertApproxEqAbs(removeDeltalp2.amount0(), removeDeltalp1.amount0() * 110 / 100, TOL);
+        assertApproxEqAbs(removeDeltalp2.amount1(), removeDeltalp1.amount1() * 120 / 100, TOL);
 
         // both must have burned their shares
         assertEq(hook.balanceOf(lp1), 0);
@@ -518,33 +617,31 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     }
 
     function test_remove_yieldsDecay_remove_multipleLP() public {
-        uint128 shareslp1 = 1e18;
         uint128 shareslp2 = 1e18;
 
-        vm.prank(lp1);
-        hook.addReHypothecatedLiquidity(shareslp1);
+        _seedBy(lp1);
         vm.prank(lp2);
         hook.addReHypothecatedLiquidity(shareslp2);
 
         // lp1 removes
         vm.prank(lp1);
-        BalanceDelta removeDeltalp1 = hook.removeReHypothecatedLiquidity(shareslp1);
+        BalanceDelta removeDeltalp1 = hook.removeReHypothecatedLiquidity(SEED_SHARES);
 
         uint256 amount0InYieldSource = hook.getAmountInYieldSource(currency0);
         uint256 amount1InYieldSource = hook.getAmountInYieldSource(currency1);
 
-        // yield1 decays by 10%
+        // yield0 decays by 10%
         hook.burnYieldSourcesBalance(currency0, amount0InYieldSource * 10 / 100);
-        // yield2 decays by 20%
+        // yield1 decays by 20%
         hook.burnYieldSourcesBalance(currency1, amount1InYieldSource * 20 / 100);
 
         // lp2 removes
         vm.prank(lp2);
         BalanceDelta removeDeltalp2 = hook.removeReHypothecatedLiquidity(shareslp2);
 
-        // lp2 must have removed less assets, since the yield decay belongs to him
-        assertApproxEqAbs(removeDeltalp2.amount0(), removeDeltalp1.amount0() * 90 / 100, 1);
-        assertApproxEqAbs(removeDeltalp2.amount1(), removeDeltalp1.amount1() * 80 / 100, 1);
+        // lp2 must have removed less assets, since the yield decay belongs to it
+        assertApproxEqAbs(removeDeltalp2.amount0(), removeDeltalp1.amount0() * 90 / 100, TOL);
+        assertApproxEqAbs(removeDeltalp2.amount1(), removeDeltalp1.amount1() * 80 / 100, TOL);
 
         // both must have burned their shares
         assertEq(hook.balanceOf(lp1), 0);
@@ -554,20 +651,29 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         assertEq(hook.totalSupply(), 0);
     }
 
-    // -- differential -- //
+    // -- DIFFERENTIAL -- //
 
-    function testFuzz_differential_add_swap_remove_SingleLP(uint256 shares, int256 amountToSwap) public {
-        shares = uint256(bound(shares, 1e12, 1e28)); // add from 0.000001 to 10B shares
+    function testFuzz_differential_add_swap_remove_SingleLP(uint256 liquidity, int256 amountToSwap) public {
+        liquidity = uint256(bound(liquidity, 1e12, 1e28)); // liquidity from 0.000001 to 10B
         amountToSwap = int256(bound(amountToSwap, 1e10, 1e26)); // swap from 0.00000001 to 100M tokens
         // assume the swap is less than half of the added liquidity
-        vm.assume(amountToSwap * 2 < int256(shares));
+        vm.assume(amountToSwap * 2 < int256(liquidity));
+
+        // amounts equivalent to `liquidity` at the current price, so the hook's JIT provision matches an
+        // equivalent plain pool position.
+        (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
+            SQRT_PRICE_1_1,
+            TickMath.getSqrtPriceAtTick(hook.getTickLower()),
+            TickMath.getSqrtPriceAtTick(hook.getTickUpper()),
+            uint128(liquidity)
+        );
 
         // -- Add liquidity --
         // Unhooked
         BalanceDelta noHookAddDelta =
-            modifyPoolLiquidity(noHookKey, hook.getTickLower(), hook.getTickUpper(), int256(uint256(shares)), 0);
+            modifyPoolLiquidity(noHookKey, hook.getTickLower(), hook.getTickUpper(), int256(liquidity), 0);
         // Hooked
-        BalanceDelta hookedAddDelta = hook.addReHypothecatedLiquidity(shares);
+        (uint256 seedShares, BalanceDelta hookedAddDelta) = hook.seedLiquidity(amount0, amount1);
         assertApproxEqAbs(hookedAddDelta, noHookAddDelta, 1, "hookedAddDelta !~= noHookAddDelta");
 
         // -- Swap --
@@ -580,39 +686,9 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         // -- Remove liquidity --
         // Unhooked
         BalanceDelta noHookRemoveDelta =
-            modifyPoolLiquidity(noHookKey, hook.getTickLower(), hook.getTickUpper(), -int256(uint256(shares)), 0);
+            modifyPoolLiquidity(noHookKey, hook.getTickLower(), hook.getTickUpper(), -int256(liquidity), 0);
         // Hooked
-        BalanceDelta hookedRemoveDelta = hook.removeReHypothecatedLiquidity(shares);
-        assertApproxEqAbs(hookedRemoveDelta, noHookRemoveDelta, 2, "hookedRemoveDelta !~= noHookRemoveDelta");
-    }
-
-    // -- decimals/rounding -- //
-
-    function testFuzz_postLossDilutionAttack_add_loss_add_SingleLP(
-        uint8 lossPercentage,
-        uint128 sharesLP1,
-        uint128 sharesLP2
-    ) public {
-        lossPercentage = uint8(bound(lossPercentage, 1, 99));
-
-        sharesLP1 = uint128(bound(sharesLP1, 1e12, 1e28));
-        sharesLP2 = uint128(bound(sharesLP2, 1, 1e28));
-
-        // lp1 adds liquidity
-        vm.prank(lp1);
-        hook.addReHypothecatedLiquidity(sharesLP1);
-
-        uint256 amount0InYieldSource = hook.getAmountInYieldSource(currency0);
-        uint256 amount1InYieldSource = hook.getAmountInYieldSource(currency1);
-
-        // the vault suffers a loss
-        hook.burnYieldSourcesBalance(currency0, amount0InYieldSource * lossPercentage / 100);
-        hook.burnYieldSourcesBalance(currency1, amount1InYieldSource * lossPercentage / 100);
-
-        // preview attacker deposit
-        (uint256 amount0, uint256 amount1) = hook.previewMint(sharesLP2);
-
-        // if shares > 0 and amounts are zero, then the attacker can mint shares freely.
-        assertFalse(sharesLP2 > 0 && (amount0 == 0 && amount1 == 0));
+        BalanceDelta hookedRemoveDelta = hook.removeReHypothecatedLiquidity(seedShares);
+        assertApproxEqAbs(hookedRemoveDelta, noHookRemoveDelta, TOL, "hookedRemoveDelta !~= noHookRemoveDelta");
     }
 }

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -110,14 +110,19 @@ contract ReentrantYieldSourceMock is ERC4626YieldSourceMock {
     }
 }
 
-/// @dev A hook that only accepts a pool with a specific fee, exercising the {_validatePoolKey} override.
+/// @dev A hook that only accepts a pool with a specific fee, exercising the `_beforeInitialize` override.
 contract ValidatingReHypothecationMock is ReHypothecationERC4626Mock {
     error WrongPool();
 
     constructor(IPoolManager pm, address ys0, address ys1) ReHypothecationERC4626Mock(pm, ys0, ys1) {}
 
-    function _validatePoolKey(PoolKey calldata key) internal pure override {
+    function _beforeInitialize(address sender, PoolKey calldata key, uint160 sqrtPriceX96)
+        internal
+        override
+        returns (bytes4)
+    {
         if (key.fee != 3000) revert WrongPool();
+        return super._beforeInitialize(sender, key, sqrtPriceX96);
     }
 }
 
@@ -910,7 +915,7 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
 
     // -- POOL KEY VALIDATION -- //
 
-    function test_validatePoolKey_override_gatesBinding() public {
+    function test_beforeInitialize_override_gatesBinding() public {
         CappedERC4626Mock ys0v = new CappedERC4626Mock(IERC20(Currency.unwrap(currency0)));
         CappedERC4626Mock ys1v = new CappedERC4626Mock(IERC20(Currency.unwrap(currency1)));
         address hookAddr = _flagAddr(0x60000000000000000000000000000000);

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -908,8 +908,8 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         assertTrue(ys1m.reentered(), "reentrancy should have been attempted");
         assertEq(
             ys1m.reentryRevertReason(),
-            abi.encodeWithSelector(ReHypothecationHook.Locked.selector),
-            "reentrant liquidity op should be blocked by the swap-cycle lock"
+            abi.encodeWithSelector(ReHypothecationHook.JITLocked.selector),
+            "reentrant liquidity op should be blocked by the JIT lock"
         );
     }
 

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -49,7 +49,12 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         yieldSource1 = IERC4626(new ERC4626YieldSourceMock(IERC20(Currency.unwrap(currency1))));
 
         hook = ReHypothecationERC4626Mock(
-            payable(address(uint160(Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG)))
+            payable(address(
+                    uint160(
+                        Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_ADD_LIQUIDITY_FLAG
+                            | Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG
+                    )
+                ))
         );
         deployCodeTo(
             "src/mocks/general/ReHypothecationERC4626Mock.sol:ReHypothecationERC4626Mock",
@@ -124,10 +129,53 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         initPool(Currency.wrap(address(0)), currency1, IHooks(address(hook)), fee, SQRT_PRICE_1_1);
     }
 
+    // -- EXTERNAL LIQUIDITY BLOCKED -- //
+
+    function test_hookPermissions_blockLiquidity() public view {
+        Hooks.Permissions memory permissions = hook.getHookPermissions();
+        assertTrue(permissions.beforeAddLiquidity, "beforeAddLiquidity should be enabled");
+        assertTrue(permissions.beforeRemoveLiquidity, "beforeRemoveLiquidity should be enabled");
+    }
+
+    function test_external_addLiquidity_reverts() public {
+        // Cache tick reads so `expectRevert` binds to the router call, not the getter sub-calls.
+        int24 tickLower = hook.getTickLower();
+        int24 tickUpper = hook.getTickUpper();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CustomRevert.WrappedError.selector,
+                address(hook),
+                IHooks.beforeAddLiquidity.selector,
+                abi.encodeWithSelector(ReHypothecationHook.LiquidityNotAllowed.selector),
+                abi.encodeWithSelector(Hooks.HookCallFailed.selector)
+            )
+        );
+        modifyPoolLiquidity(key, tickLower, tickUpper, int256(1e18), 0);
+    }
+
+    function test_external_removeLiquidity_reverts() public {
+        // Cache tick reads so `expectRevert` binds to the router call, not the getter sub-calls.
+        int24 tickLower = hook.getTickLower();
+        int24 tickUpper = hook.getTickUpper();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CustomRevert.WrappedError.selector,
+                address(hook),
+                IHooks.beforeRemoveLiquidity.selector,
+                abi.encodeWithSelector(ReHypothecationHook.LiquidityNotAllowed.selector),
+                abi.encodeWithSelector(Hooks.HookCallFailed.selector)
+            )
+        );
+        modifyPoolLiquidity(key, tickLower, tickUpper, -int256(1e18), 0);
+    }
+
     // -- ADDING -- //
 
     function test_add_uninitialized_reverts() public {
-        uint160 hookFlags = uint160(Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG);
+        uint160 hookFlags = uint160(
+            Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG
+                | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG
+        );
         ReHypothecationERC4626Mock newHook = ReHypothecationERC4626Mock(
             payable(address(hookFlags + 0x10000000000000000000000000000000)) // generate a different address
         );
@@ -284,7 +332,10 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     // -- REMOVING -- //
 
     function test_remove_uninitialized_reverts() public {
-        uint160 hookFlags = uint160(Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG);
+        uint160 hookFlags = uint160(
+            Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG
+                | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG
+        );
         ReHypothecationERC4626Mock newHook = ReHypothecationERC4626Mock(
             payable(address(hookFlags + 0x10000000000000000000000000000000)) // generate a different address
         );

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.24;
 
 // External imports
-import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
@@ -26,6 +25,23 @@ import {HookTest} from "../utils/HookTest.sol";
 import {BalanceDeltaAssertions} from "../utils/BalanceDeltaAssertions.sol";
 import {BaseHook} from "../../src/base/BaseHook.sol";
 
+/// @dev An ERC-4626 yield source whose `maxWithdraw` can be capped below its balance, to model gated or
+/// illiquid vaults when testing the withdrawable-based JIT sizing. Uncapped, it behaves like its parent.
+contract CappedERC4626Mock is ERC4626YieldSourceMock {
+    uint256 private _cap = type(uint256).max;
+
+    constructor(IERC20 token) ERC4626YieldSourceMock(token) {}
+
+    function setCap(uint256 cap) external {
+        _cap = cap;
+    }
+
+    function maxWithdraw(address owner) public view override returns (uint256) {
+        uint256 unconstrained = super.maxWithdraw(owner);
+        return unconstrained < _cap ? unconstrained : _cap;
+    }
+}
+
 contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     using StateLibrary for IPoolManager;
     using SafeCast for *;
@@ -33,8 +49,8 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
 
     ReHypothecationERC4626Mock hook;
 
-    IERC4626 yieldSource0;
-    IERC4626 yieldSource1;
+    CappedERC4626Mock yieldSource0;
+    CappedERC4626Mock yieldSource1;
 
     PoolKey noHookKey;
 
@@ -54,8 +70,8 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         deployFreshManagerAndRouters();
         deployMintAndApprove2Currencies();
 
-        yieldSource0 = IERC4626(new ERC4626YieldSourceMock(IERC20(Currency.unwrap(currency0))));
-        yieldSource1 = IERC4626(new ERC4626YieldSourceMock(IERC20(Currency.unwrap(currency1))));
+        yieldSource0 = new CappedERC4626Mock(IERC20(Currency.unwrap(currency0)));
+        yieldSource1 = new CappedERC4626Mock(IERC20(Currency.unwrap(currency1)));
 
         hook = ReHypothecationERC4626Mock(
             payable(address(
@@ -690,5 +706,25 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         // Hooked
         BalanceDelta hookedRemoveDelta = hook.removeReHypothecatedLiquidity(seedShares);
         assertApproxEqAbs(hookedRemoveDelta, noHookRemoveDelta, TOL, "hookedRemoveDelta !~= noHookRemoveDelta");
+    }
+
+    // -- JIT SIZING -- //
+
+    function test_getLiquidityToUse_sizedByWithdrawableBalance() public {
+        _seed();
+
+        uint256 liqFull = hook.getLiquidityToUse();
+        assertGt(liqFull, 0, "sanity: liquidity should be non-zero");
+
+        // Cap currency0 withdrawals well below the seeded balance.
+        uint256 cap = SEED / 1000;
+        yieldSource0.setCap(cap);
+
+        // The withdrawable amount now reflects the cap, and is below the reported balance...
+        assertEq(hook.getMaxWithdrawFromYieldSource(currency0), cap, "max withdraw != cap");
+        assertLt(cap, hook.getAmountInYieldSource(currency0), "cap should be below the reported balance");
+
+        // ...so the just-in-time liquidity is sized down accordingly, never above what can be withdrawn back.
+        assertLt(hook.getLiquidityToUse(), liqFull, "capped liquidity should be lower");
     }
 }

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -82,6 +82,45 @@ contract DynamicTickReHypothecationMock is ReHypothecationERC4626Mock {
     }
 }
 
+/// @dev A yield source that attempts to reenter the hook's `removeReHypothecatedLiquidity` on withdraw, to
+/// test that liquidity operations are locked during a swap's settlement.
+contract ReentrantYieldSourceMock is ERC4626YieldSourceMock {
+    ReHypothecationHook public hook;
+    bool public reentered;
+    bytes public reentryRevertReason;
+    bool private _armed;
+
+    constructor(IERC20 token) ERC4626YieldSourceMock(token) {}
+
+    function arm(ReHypothecationHook hook_) external {
+        hook = hook_;
+        _armed = true;
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner) public override returns (uint256) {
+        if (_armed) {
+            _armed = false;
+            reentered = true;
+            try hook.removeReHypothecatedLiquidity(1) {}
+            catch (bytes memory reason) {
+                reentryRevertReason = reason;
+            }
+        }
+        return super.withdraw(assets, receiver, owner);
+    }
+}
+
+/// @dev A hook that only accepts a pool with a specific fee, exercising the {_validatePoolKey} override.
+contract ValidatingReHypothecationMock is ReHypothecationERC4626Mock {
+    error WrongPool();
+
+    constructor(IPoolManager pm, address ys0, address ys1) ReHypothecationERC4626Mock(pm, ys0, ys1) {}
+
+    function _validatePoolKey(PoolKey calldata key) internal pure override {
+        if (key.fee != 3000) revert WrongPool();
+    }
+}
+
 contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     using StateLibrary for IPoolManager;
     using SafeCast for *;
@@ -835,5 +874,66 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
 
         (, int24 tickAfter,,) = StateLibrary.getSlot0(manager, dynKey.toId());
         assertTrue(tickBefore != tickAfter, "swap should move the tick, exercising the range shift");
+    }
+
+    // -- SETTLEMENT REENTRANCY -- //
+
+    function test_afterSwap_liquidityReentrancy_blocked() public {
+        // currency1's yield source reenters removeReHypothecatedLiquidity during afterSwap's withdrawal.
+        CappedERC4626Mock ys0m = new CappedERC4626Mock(IERC20(Currency.unwrap(currency0)));
+        ReentrantYieldSourceMock ys1m = new ReentrantYieldSourceMock(IERC20(Currency.unwrap(currency1)));
+        address hookAddr = _flagAddr(0x50000000000000000000000000000000);
+        deployCodeTo(
+            "src/mocks/general/ReHypothecationERC4626Mock.sol:ReHypothecationERC4626Mock",
+            abi.encode(address(manager), address(ys0m), address(ys1m)),
+            hookAddr
+        );
+        ReHypothecationERC4626Mock h = ReHypothecationERC4626Mock(payable(hookAddr));
+        (PoolKey memory k,) = initPool(currency0, currency1, IHooks(hookAddr), fee, SQRT_PRICE_1_1);
+
+        IERC20(Currency.unwrap(currency0)).approve(hookAddr, type(uint256).max);
+        IERC20(Currency.unwrap(currency1)).approve(hookAddr, type(uint256).max);
+        h.seedLiquidity(SEED, SEED);
+
+        ys1m.arm(h);
+
+        // zeroForOne swap → hook owes currency1 → withdraw(currency1) in afterSwap → reentrancy attempt.
+        swap(k, true, -1e15, ZERO_BYTES);
+
+        assertTrue(ys1m.reentered(), "reentrancy should have been attempted");
+        assertEq(
+            ys1m.reentryRevertReason(),
+            abi.encodeWithSelector(ReHypothecationHook.Locked.selector),
+            "reentrant liquidity op should be blocked by the swap-cycle lock"
+        );
+    }
+
+    // -- POOL KEY VALIDATION -- //
+
+    function test_validatePoolKey_override_gatesBinding() public {
+        CappedERC4626Mock ys0v = new CappedERC4626Mock(IERC20(Currency.unwrap(currency0)));
+        CappedERC4626Mock ys1v = new CappedERC4626Mock(IERC20(Currency.unwrap(currency1)));
+        address hookAddr = _flagAddr(0x60000000000000000000000000000000);
+        deployCodeTo(
+            "test/general/ReHypothecationHookERC4626.t.sol:ValidatingReHypothecationMock",
+            abi.encode(address(manager), address(ys0v), address(ys1v)),
+            hookAddr
+        );
+
+        // A pool with the wrong fee (1000) is rejected by the override, so the hook stays unbound.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CustomRevert.WrappedError.selector,
+                hookAddr,
+                IHooks.beforeInitialize.selector,
+                abi.encodeWithSelector(ValidatingReHypothecationMock.WrongPool.selector),
+                abi.encodeWithSelector(Hooks.HookCallFailed.selector)
+            )
+        );
+        initPool(currency0, currency1, IHooks(hookAddr), 1000, SQRT_PRICE_1_1);
+
+        // The expected fee (3000) is accepted and binds the hook.
+        initPool(currency0, currency1, IHooks(hookAddr), 3000, SQRT_PRICE_1_1);
+        assertEq(ValidatingReHypothecationMock(payable(hookAddr)).getPoolKey().fee, 3000);
     }
 }

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -42,6 +42,46 @@ contract CappedERC4626Mock is ERC4626YieldSourceMock {
     }
 }
 
+/// @dev An ERC-4626 yield source that reverts on zero-amount deposits/withdrawals, like several real lending
+/// protocols, to test that the hook skips zero-amount yield-source calls.
+contract RevertOnZeroERC4626Mock is ERC4626YieldSourceMock {
+    error ZeroAmount();
+
+    constructor(IERC20 token) ERC4626YieldSourceMock(token) {}
+
+    function deposit(uint256 assets, address receiver) public override returns (uint256) {
+        if (assets == 0) revert ZeroAmount();
+        return super.deposit(assets, receiver);
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner) public override returns (uint256) {
+        if (assets == 0) revert ZeroAmount();
+        return super.withdraw(assets, receiver, owner);
+    }
+}
+
+/// @dev A rehypothecation hook whose position range tracks the current pool tick, so the range shifts as a swap
+/// moves the price. Used to test that the position's tick bounds are snapshotted across a swap.
+contract DynamicTickReHypothecationMock is ReHypothecationERC4626Mock {
+    using StateLibrary for IPoolManager;
+
+    constructor(IPoolManager pm, address ys0, address ys1) ReHypothecationERC4626Mock(pm, ys0, ys1) {}
+
+    function getTickLower() public view override returns (int24) {
+        return _center() - 10 * getPoolKey().tickSpacing;
+    }
+
+    function getTickUpper() public view override returns (int24) {
+        return _center() + 10 * getPoolKey().tickSpacing;
+    }
+
+    function _center() private view returns (int24) {
+        (, int24 tick,,) = poolManager.getSlot0(getPoolKey().toId());
+        int24 spacing = getPoolKey().tickSpacing;
+        return (tick / spacing) * spacing;
+    }
+}
+
 contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     using StateLibrary for IPoolManager;
     using SafeCast for *;
@@ -133,6 +173,15 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
 
     function _seed() internal returns (uint256 shares) {
         (shares,) = hook.seedLiquidity(SEED, SEED);
+    }
+
+    /// @dev A distinct hook address carrying the required permission flag bits, offset by `nudge`.
+    function _flagAddr(uint160 nudge) internal pure returns (address) {
+        uint160 flags = uint160(
+            Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG
+                | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG
+        );
+        return address(flags + nudge);
     }
 
     // -- INITIALIZING -- //
@@ -726,5 +775,65 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
 
         // ...so the just-in-time liquidity is sized down accordingly, never above what can be withdrawn back.
         assertLt(hook.getLiquidityToUse(), liqFull, "capped liquidity should be lower");
+    }
+
+    // -- ZERO-AMOUNT YIELD-SOURCE CALLS -- //
+
+    function test_remove_zeroLeg_skipsZeroYieldSourceWithdraw() public {
+        // currency0's yield source reverts on zero-amount withdrawals.
+        RevertOnZeroERC4626Mock ys0r = new RevertOnZeroERC4626Mock(IERC20(Currency.unwrap(currency0)));
+        CappedERC4626Mock ys1r = new CappedERC4626Mock(IERC20(Currency.unwrap(currency1)));
+        address hookAddr = _flagAddr(0x30000000000000000000000000000000);
+        deployCodeTo(
+            "src/mocks/general/ReHypothecationERC4626Mock.sol:ReHypothecationERC4626Mock",
+            abi.encode(address(manager), address(ys0r), address(ys1r)),
+            hookAddr
+        );
+        ReHypothecationERC4626Mock h = ReHypothecationERC4626Mock(payable(hookAddr));
+        initPool(currency0, currency1, IHooks(hookAddr), fee, SQRT_PRICE_1_1);
+
+        IERC20(Currency.unwrap(currency0)).approve(hookAddr, type(uint256).max);
+        IERC20(Currency.unwrap(currency1)).approve(hookAddr, type(uint256).max);
+        h.seedLiquidity(SEED, SEED);
+
+        // Drain currency0's yield source so a proportional redeem prices its leg to zero (rounds down).
+        h.burnYieldSourcesBalance(currency0, h.getAmountInYieldSource(currency0));
+
+        uint256 smallShares = 1e6;
+        (uint256 amount0, uint256 amount1) = h.previewRedeem(smallShares);
+        assertEq(amount0, 0, "currency0 leg should redeem to zero");
+        assertGt(amount1, 0, "currency1 leg should be non-zero");
+
+        // Must not revert: the zero currency0 withdrawal is skipped instead of hitting the reverting yield source.
+        h.removeReHypothecatedLiquidity(smallShares);
+    }
+
+    // -- JIT TICK SNAPSHOT -- //
+
+    function test_swap_dynamicTicks_snapshotsRangeAcrossSwap() public {
+        CappedERC4626Mock ys0d = new CappedERC4626Mock(IERC20(Currency.unwrap(currency0)));
+        CappedERC4626Mock ys1d = new CappedERC4626Mock(IERC20(Currency.unwrap(currency1)));
+        address hookAddr = _flagAddr(0x40000000000000000000000000000000);
+        deployCodeTo(
+            "test/general/ReHypothecationHookERC4626.t.sol:DynamicTickReHypothecationMock",
+            abi.encode(address(manager), address(ys0d), address(ys1d)),
+            hookAddr
+        );
+        DynamicTickReHypothecationMock h = DynamicTickReHypothecationMock(payable(hookAddr));
+        (PoolKey memory dynKey,) = initPool(currency0, currency1, IHooks(hookAddr), fee, SQRT_PRICE_1_1);
+
+        IERC20(Currency.unwrap(currency0)).approve(hookAddr, type(uint256).max);
+        IERC20(Currency.unwrap(currency1)).approve(hookAddr, type(uint256).max);
+        h.seedLiquidity(SEED, SEED);
+
+        (, int24 tickBefore,,) = StateLibrary.getSlot0(manager, dynKey.toId());
+
+        // A large exact-input swap moves the tick, so the dynamic range would shift between beforeSwap and
+        // afterSwap. With the range snapshotted, afterSwap removes exactly what beforeSwap added and the swap
+        // succeeds; without it the position would be orphaned and the swap would revert.
+        swap(dynKey, true, -5e17, ZERO_BYTES);
+
+        (, int24 tickAfter,,) = StateLibrary.getSlot0(manager, dynKey.toId());
+        assertTrue(tickBefore != tickAfter, "swap should move the tick, exercising the range shift");
     }
 }

--- a/test/general/ReHypothecationHookNative.t.sol
+++ b/test/general/ReHypothecationHookNative.t.sol
@@ -13,6 +13,8 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
+import {LiquidityAmounts} from "@uniswap/v4-core/test/utils/LiquidityAmounts.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
 // Internal imports
 import {ReHypothecationNativeMock, NativeYieldSourceMock} from "../../src/mocks/general/ReHypothecationNativeMock.sol";
 import {ERC4626YieldSourceMock} from "../../src/mocks/general/ReHypothecationERC4626Mock.sol";
@@ -126,18 +128,31 @@ contract ReHypothecationHookNativeTest is HookTest, BalanceDeltaAssertions {
     // -- DIFFERENTIAL TESTING -- //
 
     function test_differential_add_swap_remove() public {
-        uint256 shares = 1e18;
+        uint256 liquidity = 1e18;
         int256 amountToSwap = -1e14; // exact input
 
-        // Add liquidity
-        BalanceDelta noHookAddDelta = modifyLiquidityRouter.modifyLiquidity{value: 1e18}(
+        // amounts equivalent to `liquidity` at the current price, so the hook's JIT provision matches an
+        // equivalent plain pool position.
+        (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
+            SQRT_PRICE_1_1,
+            TickMath.getSqrtPriceAtTick(hook.getTickLower()),
+            TickMath.getSqrtPriceAtTick(hook.getTickUpper()),
+            uint128(liquidity)
+        );
+
+        // Add liquidity. `amount0` rounds down, while the pool charges the rounded-up amount, so fund the
+        // router with the full `liquidity`-equivalent native value (any excess does not affect the delta).
+        BalanceDelta noHookAddDelta = modifyLiquidityRouter.modifyLiquidity{value: liquidity}(
             noHookKey,
             ModifyLiquidityParams({
-                tickLower: hook.getTickLower(), tickUpper: hook.getTickUpper(), liquidityDelta: int256(shares), salt: 0
+                tickLower: hook.getTickLower(),
+                tickUpper: hook.getTickUpper(),
+                liquidityDelta: int256(liquidity),
+                salt: 0
             }),
             ""
         );
-        BalanceDelta hookedAddDelta = hook.addReHypothecatedLiquidity{value: 1e18}(shares);
+        (uint256 seedShares, BalanceDelta hookedAddDelta) = hook.seedLiquidity{value: amount0}(amount0, amount1);
         assertApproxEqAbs(hookedAddDelta, noHookAddDelta, 10, "hookedAddDelta !~= noHookAddDelta");
 
         // Swap
@@ -146,10 +161,10 @@ contract ReHypothecationHookNativeTest is HookTest, BalanceDeltaAssertions {
         BalanceDelta hookedSwapDelta = swapNativeInput(key, true, amountToSwap, ZERO_BYTES, (-amountToSwap).toUint256());
         assertApproxEqAbs(hookedSwapDelta, noHookSwapDelta, 10, "hookedSwapDelta !~= noHookSwapDelta");
 
-        // // Remove liquidity
+        // Remove liquidity
         BalanceDelta noHookRemoveDelta =
-            modifyPoolLiquidity(noHookKey, hook.getTickLower(), hook.getTickUpper(), -int256(shares), 0);
-        BalanceDelta hookedRemoveDelta = hook.removeReHypothecatedLiquidity(shares);
-        assertApproxEqAbs(hookedRemoveDelta, noHookRemoveDelta, 2, "hookedRemoveDelta !~= noHookRemoveDelta");
+            modifyPoolLiquidity(noHookKey, hook.getTickLower(), hook.getTickUpper(), -int256(liquidity), 0);
+        BalanceDelta hookedRemoveDelta = hook.removeReHypothecatedLiquidity(seedShares);
+        assertApproxEqAbs(hookedRemoveDelta, noHookRemoveDelta, 1e9, "hookedRemoveDelta !~= noHookRemoveDelta");
     }
 }

--- a/test/general/ReHypothecationHookNative.t.sol
+++ b/test/general/ReHypothecationHookNative.t.sol
@@ -44,7 +44,12 @@ contract ReHypothecationHookNativeTest is HookTest, BalanceDeltaAssertions {
         yieldSource1 = new ERC4626YieldSourceMock(IERC20(Currency.unwrap(currency1)));
 
         hook = ReHypothecationNativeMock(
-            payable(address(uint160(Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG)))
+            payable(address(
+                    uint160(
+                        Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_ADD_LIQUIDITY_FLAG
+                            | Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG
+                    )
+                ))
         );
         deployCodeTo(
             "src/mocks/general/ReHypothecationNativeMock.sol:ReHypothecationNativeMock",
@@ -101,7 +106,10 @@ contract ReHypothecationHookNativeTest is HookTest, BalanceDeltaAssertions {
 
     function test_initialize_native_currency_supported() public {
         // Native currency (address(0)) should be supported in the native mock
-        uint160 hookFlags = uint160(Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG);
+        uint160 hookFlags = uint160(
+            Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG
+                | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG
+        );
         ReHypothecationNativeMock newHook = ReHypothecationNativeMock(
             payable(address(hookFlags + 0x10000000000000000000000000000000)) // generate a different address
         );


### PR DESCRIPTION
## Restrict liquidity provision to the hook

Enables `beforeAddLiquidity`/`beforeRemoveLiquidity` and reverts direct third-party liquidity operations on the pool, so the hook remains the sole liquidity provider for its pool. The hook's own just-in-time liquidity is unaffected, since the `PoolManager` skips hook callbacks when the hook itself modifies liquidity. This prevents external positions from interfering with the hook's position, for example by saturating its tick boundaries.

## Redefine shares and pricing

Replaces the previous two-regime pricing (internal pool price at genesis, proportional to yield-source balances afterwards) with a single proportional model using an EIP-4626 style virtual offset:

    amountX = shares * (balanceX + 1) / (totalSupply + 10 ** _decimalsOffset())

The first liquidity is provided through a new one-time, permissionless `seedLiquidity(amount0, amount1)`, which sets the initial ratio and mints `sqrt(amount0 * amount1)` shares (UniswapV2 style), requiring at least `100 * 10 ** _decimalsOffset()` shares so the supply dominates the offset. `addReHypothecatedLiquidity` now requires a seeded pool. `_decimalsOffset()` is `virtual` (default 6) so integrators can adjust the inflation-defense strength.

This removes the degenerate genesis and depleted-balance edge cases in the earlier pricing (see #139).