### PR TITLE
ci: run coverage with the oracle gas limit

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -50,7 +50,9 @@ jobs:
         uses: ./.github/actions/setup
       
       - name: Generate coverage
-        run: forge coverage --report lcov
+        # Use the oracle gas limit (see `[profile.oracle]` in foundry.toml): the panoptic oracle tests need
+        # more than the default `gas_limit`, and coverage's unoptimized build makes them exceed it and revert.
+        run: forge coverage --report lcov --gas-limit 300000000
       
       - uses: codecov/codecov-action@v5
         env:


### PR DESCRIPTION
The `Coverage` job runs `forge coverage` on the default Foundry profile, whose `gas_limit` (200000000) is lower than the panoptic oracle tests require. `foundry.toml` already grants them a higher limit via `[profile.oracle]` (300000000), but the coverage step does not use it, so under coverage's unoptimized build the `OracleLibTest` tests exceed the default limit and revert — failing the job.

Passing `--gas-limit 300000000` to the coverage run lets those tests fit. Verified locally: running the oracle suite under coverage with the 300000000 limit passes all 81 tests, while the default limit reverts 11 of them at the ~2e8 ceiling.

Only touches the coverage step in `.github/workflows/checks.yml`; no source changes.