### PR TITLE
LimitOrderHook: let a subclass fill the orders its own swaps cross

### DIFF
--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -52,9 +52,14 @@ library OrderIdLibrary {
  * Orders can be cancelled at any time until they are filled and their liquidity is removed from the pool.
  * Once completely filled, the resulting liquidity can be withdrawn from the pool.
  *
- * IMPORTANT: Fees accrued by an order are credited per unit of liquidity, so each owner is entitled to the
+ * NOTE: Fees accrued by an order are credited per unit of liquidity, so each owner is entitled to the
  * fees earned while its liquidity was in the order and to none of those earned before it. Amounts are truncated
  * in the order's favour, so a negligible residual can remain in the hook.
+ *
+ * IMPORTANT: Uniswap V4 does not call a hook's own callbacks when that hook is the caller, so {_afterSwap}
+ * does not run for a swap this hook makes itself. A subclass that swaps internally MUST call
+ * {_fillCrossedOrders} afterwards, or the tick recorded for the pool falls behind the price and the next
+ * crossing is measured from it.
  *
  * WARNING: This is experimental software and is provided on an "as is" and "as available" basis. We do
  * not give any warranties and will not be liable for any losses incurred through any use of this code
@@ -222,26 +227,14 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         return this.afterInitialize.selector;
     }
 
-    /// @dev Hooks into the `afterSwap` hook to get the ticks crossed by the swap and fill the orders that are crossed, filling them.
+    /// @dev Hooks into the `afterSwap` hook to fill the orders the swap crossed.
     function _afterSwap(address, PoolKey calldata key, SwapParams calldata params, BalanceDelta, bytes calldata)
         internal
         virtual
         override
         returns (bytes4, int128)
     {
-        (int24 tickLower, int24 lower, int24 upper) = _getCrossedTicks(key.toId(), key.tickSpacing);
-
-        if (lower > upper) return (this.afterSwap.selector, 0);
-
-        // set the last tick lower for the pool
-        _tickLowerLasts[key.toId()] = tickLower;
-
-        // note that a zeroForOne swap means that the pool is actually gaining token0, so limit
-        // order fills are the opposite of swap fills, hence the inversion below
-        bool zeroForOne = !params.zeroForOne;
-        for (; lower <= upper; lower += key.tickSpacing) {
-            _fillOrder(key, lower, zeroForOne);
-        }
+        _fillCrossedOrders(key, params.zeroForOne);
 
         return (this.afterSwap.selector, 0);
     }
@@ -577,11 +570,33 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     }
 
     /**
+     * @dev Fills the orders the price crossed since the tick last recorded for `key`, and records the tick
+     * it reached. `swapZeroForOne` is the swap's direction, not the filled orders'.
+     *
+     * IMPORTANT: A subclass that swaps inside its own unlock callback must call this afterwards, since the
+     * pool does not report such a swap.
+     */
+    function _fillCrossedOrders(PoolKey memory key, bool swapZeroForOne) internal virtual {
+        PoolId poolId = key.toId();
+        (int24 tickLower, int24 lower, int24 upper) = _getCrossedTicks(poolId, key.tickSpacing);
+
+        if (lower > upper) return;
+
+        // set the last tick lower for the pool
+        _tickLowerLasts[poolId] = tickLower;
+
+        bool zeroForOne = !swapZeroForOne;
+        for (; lower <= upper; lower += key.tickSpacing) {
+            _fillOrder(key, lower, zeroForOne);
+        }
+    }
+
+    /**
      * @dev Internal handler for filling limit orders when price crosses a tick. Takes a `PoolKey` `key`, target `tickLower`,
      * and direction `zeroForOne`. Removes liquidity from filled orders, mints the received currencies to the hook, and
      * updates order state to track filled amounts.
      */
-    function _fillOrder(PoolKey calldata key, int24 tickLower, bool zeroForOne) internal virtual {
+    function _fillOrder(PoolKey memory key, int24 tickLower, bool zeroForOne) internal virtual {
         // slither-disable-start calls-loop
         OrderIdLibrary.OrderId orderId = getOrderId(key, tickLower, zeroForOne);
 

--- a/src/mocks/general/LimitOrderHookMock.sol
+++ b/src/mocks/general/LimitOrderHookMock.sol
@@ -3,12 +3,67 @@ pragma solidity ^0.8.26;
 
 // External imports
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 // Internal imports
+import {CurrencySettler} from "../../utils/CurrencySettler.sol";
 import {LimitOrderHook} from "../../general/LimitOrderHook.sol";
 import {BaseHook} from "../../base/BaseHook.sol";
 
 contract LimitOrderHookMock is LimitOrderHook {
+    using CurrencySettler for *;
+
+    /// @dev Tags the callback as this contract's own. `LimitOrderHook`'s callbacks encode `0x20` first.
+    uint256 private constant INTERNAL_SWAP_TAG = type(uint256).max;
+
     constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
+
+    /**
+     * @dev Swaps `amount` toward `targetTick` from inside this hook's own unlock callback, which the pool
+     * does not report. Fills the orders it crossed when `fillCrossed`, and models the subclass that forgets
+     * to otherwise.
+     */
+    function internalSwap(PoolKey calldata key, int24 targetTick, uint256 amount, bool fillCrossed) external {
+        poolManager.unlock(abi.encode(INTERNAL_SWAP_TAG, key, targetTick, amount, fillCrossed));
+    }
+
+    function unlockCallback(bytes calldata rawData) public virtual override onlyPoolManager returns (bytes memory) {
+        if (abi.decode(rawData[:32], (uint256)) != INTERNAL_SWAP_TAG) return super.unlockCallback(rawData);
+
+        (, PoolKey memory key, int24 targetTick, uint256 amount, bool fillCrossed) =
+            abi.decode(rawData, (uint256, PoolKey, int24, uint256, bool));
+
+        SwapParams memory params = SwapParams({
+            zeroForOne: targetTick < _getCurrentTick(key.toId()),
+            amountSpecified: -int256(amount),
+            sqrtPriceLimitX96: TickMath.getSqrtPriceAtTick(targetTick)
+        });
+
+        BalanceDelta delta = poolManager.swap(key, params, "");
+
+        if (fillCrossed) _fillCrossedOrders(key, params.zeroForOne);
+
+        _settle(key, delta);
+
+        return "";
+    }
+
+    function _settle(PoolKey memory key, BalanceDelta delta) private {
+        if (delta.amount0() < 0) {
+            key.currency0.settle(poolManager, address(this), uint256(uint128(-delta.amount0())), false);
+        }
+        if (delta.amount1() < 0) {
+            key.currency1.settle(poolManager, address(this), uint256(uint128(-delta.amount1())), false);
+        }
+        if (delta.amount0() > 0) {
+            key.currency0.take(poolManager, address(this), uint256(uint128(delta.amount0())), false);
+        }
+        if (delta.amount1() > 0) {
+            key.currency1.take(poolManager, address(this), uint256(uint128(delta.amount1())), false);
+        }
+    }
 
     // exclude from coverage report
     function test() public {}

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -129,6 +129,20 @@ contract LimitOrderHookTest is HookTest {
         );
     }
 
+    /// @dev The pool's current tick, rounded down to a tick lower.
+    function currentTickLower() internal view returns (int24) {
+        (, int24 tick,,) = manager.getSlot0(key.toId());
+        int24 compressed = tick / tickSpacing;
+        if (tick < 0 && tick % tickSpacing != 0) compressed--;
+        return compressed * tickSpacing;
+    }
+
+    /// @dev The hook pays for the swaps it makes itself.
+    function fundHook() internal {
+        IERC20Minimal(Currency.unwrap(currency0)).transfer(address(hook), 1e24);
+        IERC20Minimal(Currency.unwrap(currency1)).transfer(address(hook), 1e24);
+    }
+
     function rawOrderIdOf(PoolKey memory poolKey, int24 tickLower, bool zeroForOne) internal view returns (uint232) {
         return OrderIdLibrary.OrderId.unwrap(hook.getOrderId(poolKey, tickLower, zeroForOne));
     }
@@ -687,6 +701,72 @@ contract LimitOrderHookTest is HookTest {
         OrderInfoView memory order = getOrderInfoView(rawOrderIdOf(key, orderTick, true));
         assertEq(order.accFee0PerLiqX128, 0, "the new order credited currency0 fees it did not earn");
         assertEq(order.accFee1PerLiqX128, 0, "the new order credited currency1 fees it did not earn");
+    }
+
+    /// @dev The mirror of the downward landing: a swap stopping exactly on a `zeroForOne` order's upper
+    /// bound has converted its position wholly into the bought currency, so it fills.
+    function test_fill_landingOnTheOrdersUpperBound() public {
+        int24 orderTick = 0;
+        uint128 liquidity = 1e15;
+
+        hook.placeOrder(key, orderTick, true, liquidity);
+
+        vm.prank(swapper);
+        swapToLimit(key, false, -1e24, orderTick + tickSpacing);
+
+        (uint160 sqrtPriceX96,,,) = manager.getSlot0(key.toId());
+        assertEq(
+            sqrtPriceX96,
+            TickMath.getSqrtPriceAtTick(orderTick + tickSpacing),
+            "the swap should stop exactly on the upper bound"
+        );
+
+        OrderInfoView memory order = getOrderInfoView(1);
+        assertTrue(order.filled, "an order converted at its upper bound should fill");
+        assertGt(order.principalCredited1, 0, "the fill should credit the bought currency");
+        assertEq(getLiquidityInPosition(key, orderTick, true), 0, "the fill should empty the position");
+    }
+
+    /// @dev The pool does not report a swap the hook makes from inside its own unlock callback, so the
+    /// hook records nothing for it and the recorded tick falls behind the price.
+    function test_fill_internalSwapDoesNotRecordTheTick() public {
+        fundHook();
+        int24 recordedBefore = hook.getTickLowerLast(key.toId());
+
+        hook.internalSwap(key, 3 * tickSpacing, 1e18, false);
+
+        assertGt(currentTickLower(), recordedBefore, "the swap should move the price");
+        assertEq(hook.getTickLowerLast(key.toId()), recordedBefore, "the hook should record nothing for it");
+    }
+
+    /// @dev A subclass that calls `_fillCrossedOrders` after its own swap records the tick and fills what
+    /// the swap crossed, which is what the pool would have done for an external swap.
+    function test_fill_internalSwapFillsCrossedOrders() public {
+        fundHook();
+        int24 orderTick = tickSpacing;
+        hook.placeOrder(key, orderTick, true, 1e15);
+
+        hook.internalSwap(key, 4 * tickSpacing, 1e18, true);
+
+        OrderInfoView memory order = getOrderInfoView(1);
+        assertTrue(order.filled, "the crossed order should fill");
+        assertGt(order.principalCredited1, 0, "the fill should credit the bought currency");
+        assertEq(order.principalCredited0, 0, "the fill should not credit the deposited currency");
+        assertEq(hook.getTickLowerLast(key.toId()), currentTickLower(), "the tick reached should be recorded");
+    }
+
+    /// @dev The same swap without that call leaves the order in the pool with the price past it.
+    function test_fill_internalSwapWithoutFillLeavesCrossedOrder() public {
+        fundHook();
+        int24 orderTick = tickSpacing;
+        uint128 liquidity = 1e15;
+        hook.placeOrder(key, orderTick, true, liquidity);
+
+        hook.internalSwap(key, 4 * tickSpacing, 1e18, false);
+
+        assertGt(currentTickLower(), orderTick, "the price should be past the order");
+        assertFalse(getOrderInfoView(1).filled, "the crossed order should stay unfilled");
+        assertEq(getLiquidityInPosition(key, orderTick, true), liquidity, "liquidity should stay in the pool");
     }
 
     // ------------------------------------- Withdraw ------------------------------------- //

--- a/test/invariant/handlers/LimitOrderHook/LimitOrderHookHandler.sol
+++ b/test/invariant/handlers/LimitOrderHook/LimitOrderHookHandler.sol
@@ -232,6 +232,19 @@ contract LimitOrderHookHandler is BaseHandler {
         _swap(target < current, bound(amountSeed, AMOUNT_MIN_BOUND, AMOUNT_MAX_BOUND), target);
     }
 
+    /// @dev Moves the price from inside the hook's own unlock callback, which the pool does not report,
+    /// and fills what it crossed, as a subclass doing this must.
+    function internalSwapTo(uint256 tickSeed, uint256 amountSeed)
+        external
+        recordCall("internalSwapTo")
+        stateTransition
+    {
+        int24 target = _tickFromSeed(tickSeed);
+        vm.assume(target != _currentTick());
+
+        hook.internalSwap(key, target, bound(amountSeed, AMOUNT_MIN_BOUND, AMOUNT_MAX_BOUND), true);
+    }
+
     /// @dev Price excursion into a tick range and back out, without crossing it: fees accrue and no
     /// order fills. One action because the fuzzer rarely composes it from two.
     function swapRoundTrip(uint256 tickSeed, uint256 amountSeed) external recordCall("swapRoundTrip") stateTransition {

--- a/test/invariant/invariants/LimitOrderHook/LimitOrderHookInvariants.t.sol
+++ b/test/invariant/invariants/LimitOrderHook/LimitOrderHookInvariants.t.sol
@@ -79,6 +79,8 @@ contract LimitOrderHookInvariantsTest is HookTest {
             _fund(actors[i]);
         }
         _fund(address(handler));
+        // the hook pays for the swaps it makes itself
+        _fund(address(hook));
 
         targetContract(address(handler));
     }


### PR DESCRIPTION
Fixes #132.
Alternative to https://github.com/OpenZeppelin/uniswap-hooks/pull/133

The fill window is measured from the tick the hook records in `_afterSwap`. Uniswap V4 does not call a hook's own callbacks when that hook is the caller, so a swap the hook makes itself leaves the recorded tick behind the price. The next crossing then scans ticks the price never reached, and filling an order there credited the currency its owner deposited and retired the key in the same call.

Extracts the scan into `_fillCrossedOrders`, which records the tick and fills what the swap crossed. A subclass that swaps internally MUST call it afterwards. `_fillOrder` now takes `memory`, which breaks a subclass overriding it.