### PR TITLE
Pay the native currency from the contract that holds it

### DIFF
--- a/src/base/BaseCustomAccounting.sol
+++ b/src/base/BaseCustomAccounting.sol
@@ -265,8 +265,15 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
 
         // Handle each currency amount based on its sign after applying the liquidity modification
         if (principalDelta.amount0() < 0) {
-            // If amount0 is negative, send tokens from the sender to the pool
-            key.currency0.settle(poolManager, data.sender, uint256(int256(-principalDelta.amount0())), false);
+            // If amount0 is negative, send tokens from the sender to the pool. The native currency is paid
+            // from this contract, which holds the sender's value for the length of the call
+            key.currency0
+                .settle(
+                    poolManager,
+                    key.currency0.isAddressZero() ? address(this) : data.sender,
+                    uint256(int256(-principalDelta.amount0())),
+                    false
+                );
         } else {
             // If amount0 is positive, send tokens from the pool to the sender
             key.currency0.take(poolManager, data.sender, uint256(int256(principalDelta.amount0())), false);

--- a/src/base/BaseCustomCurve.sol
+++ b/src/base/BaseCustomCurve.sol
@@ -244,8 +244,15 @@ abstract contract BaseCustomCurve is BaseCustomAccounting {
 
         // Add liquidity if amount0 is positive
         if (data.amount0 > 0) {
-            // First settle (send) tokens from user to pool
-            key.currency0.settle(poolManager, data.sender, uint256(int256(data.amount0)), false);
+            // First settle (send) tokens from user to pool. The native currency is paid from this
+            // contract, which holds the sender's value for the length of the call
+            key.currency0
+                .settle(
+                    poolManager,
+                    key.currency0.isAddressZero() ? address(this) : data.sender,
+                    uint256(int256(data.amount0)),
+                    false
+                );
             // Take (mint) ERC-6909 tokens to be received by this hook
             key.currency0.take(poolManager, address(this), uint256(int256(data.amount0)), true);
             // Record the amount so that it can be then encoded into the delta

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -56,6 +56,8 @@ library OrderIdLibrary {
  * fees earned while its liquidity was in the order and to none of those earned before it. Amounts are truncated
  * in the order's favour, so a negligible residual can remain in the hook.
  *
+ * NOTE: Native currency orders are not supported.
+ *
  * IMPORTANT: Uniswap V4 does not call a hook's own callbacks when that hook is the caller, so {_afterSwap}
  * does not run for a swap this hook makes itself. A subclass that swaps internally MUST call
  * {_fillCrossedOrders} afterwards, or the tick recorded for the pool falls behind the price and the next
@@ -175,6 +177,9 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     /// @dev Limit order is not filled.
     error NotFilled();
 
+    /// @dev Limit order was placed in a pool holding the native currency.
+    error NativeCurrencyUnsupported();
+
     /**
      * @dev Emitted when an `owner` places a limit order with the given `orderId`, in the pool identified by `key`,
      * at the given `tickLower`, `zeroForOne` indicating the direction of the order, and `liquidity` the amount of liquidity
@@ -258,6 +263,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         onlyValidPools(key.hooks)
     {
         if (liquidity == 0) revert ZeroLiquidity();
+
+        if (key.currency0.isAddressZero()) revert NativeCurrencyUnsupported();
 
         OrderInfo storage orderInfo;
 

--- a/src/utils/CurrencySettler.sol
+++ b/src/utils/CurrencySettler.sol
@@ -21,11 +21,16 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 library CurrencySettler {
     using SafeERC20 for IERC20;
 
+    /// @dev The native currency was settled on behalf of a `payer` other than the contract paying it.
+    error InvalidNativePayer(address payer);
+
     /**
      * @notice Settle (pay) a currency to the `PoolManager`
      * @param currency Currency to settle
      * @param poolManager `PoolManager` to settle to
-     * @param payer Address of the payer, which can be the hook itself or an external address.
+     * @param payer Address of the payer, which can be the hook itself or an external address. The native
+     * currency is paid from the balance of the calling contract, so `payer` must be that contract when
+     * `currency` is native and `burn` is false, otherwise the call reverts with {InvalidNativePayer}.
      * @param amount Amount to send
      * @param burn If true, burn the ERC-6909 token, otherwise transfer ERC-20 to the `PoolManager`
      */
@@ -38,6 +43,10 @@ library CurrencySettler {
         if (burn) {
             poolManager.burn(payer, currency.toId(), amount);
         } else if (currency.isAddressZero()) {
+            // the value is paid from the balance of the calling contract, so settling for another payer
+            // would spend currency that payer never provided
+            if (payer != address(this)) revert InvalidNativePayer(payer);
+
             poolManager.sync(currency);
             poolManager.settle{value: amount}();
         } else {

--- a/test/general/LimitOrderHookNative.t.sol
+++ b/test/general/LimitOrderHookNative.t.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Hooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {IHooks} from "@uniswap/v4-core/src/interfaces/IHooks.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {IERC20Minimal} from "@uniswap/v4-core/src/interfaces/external/IERC20Minimal.sol";
+// Internal imports
+import {LimitOrderHook, OrderIdLibrary} from "src/general/LimitOrderHook.sol";
+import {LimitOrderHookMock} from "src/mocks/general/LimitOrderHookMock.sol";
+import {CurrencySettler} from "src/utils/CurrencySettler.sol";
+import {HookTest} from "../utils/HookTest.sol";
+
+/// @dev Calls {CurrencySettler-settle} directly, to reach the library from outside a hook.
+contract CurrencySettlerMock {
+    function settleNative(IPoolManager poolManager, address payer, uint256 amount) external {
+        CurrencySettler.settle(Currency.wrap(address(0)), poolManager, payer, amount, false);
+    }
+}
+
+contract LimitOrderHookNativeTest is HookTest {
+    LimitOrderHookMock hook;
+
+    address user = makeAddr("user");
+    address swapper = makeAddr("swapper");
+    address attacker = makeAddr("attacker");
+
+    int24 tickSpacing;
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        deployMintAndApprove2Currencies();
+
+        hook = LimitOrderHookMock(address(uint160(Hooks.AFTER_INITIALIZE_FLAG | Hooks.AFTER_SWAP_FLAG)));
+        deployCodeTo(
+            "src/mocks/general/LimitOrderHookMock.sol:LimitOrderHookMock", abi.encode(address(manager)), address(hook)
+        );
+
+        (nativeKey,) = initPool(Currency.wrap(address(0)), currency1, IHooks(address(hook)), 3000, SQRT_PRICE_1_1);
+        tickSpacing = nativeKey.tickSpacing;
+
+        address[3] memory holders = [user, swapper, attacker];
+        for (uint256 i = 0; i < holders.length; i++) {
+            deal(holders[i], 1e24);
+            IERC20Minimal(Currency.unwrap(currency1)).transfer(holders[i], 1e30);
+
+            vm.startPrank(holders[i]);
+            IERC20Minimal(Currency.unwrap(currency1)).approve(address(hook), type(uint256).max);
+            IERC20Minimal(Currency.unwrap(currency1)).approve(address(swapRouter), type(uint256).max);
+            IERC20Minimal(Currency.unwrap(currency1)).approve(address(modifyLiquidityRouter), type(uint256).max);
+            vm.stopPrank();
+        }
+
+        deal(address(this), 1e24);
+    }
+
+    /// @dev The placer settles the currency their order sells, and the native currency is paid from the
+    /// hook's balance rather than theirs. The hook serves no pool holding it, in either direction, so
+    /// whatever balance it holds stays where it is.
+    function test_placeOrder_native_reverts() public {
+        uint256 seeded = 5 ether;
+        vm.deal(address(hook), seeded);
+
+        vm.prank(attacker);
+        vm.expectRevert(LimitOrderHook.NativeCurrencyUnsupported.selector);
+        hook.placeOrder(nativeKey, tickSpacing, true, 1e18);
+
+        vm.prank(attacker);
+        vm.expectRevert(LimitOrderHook.NativeCurrencyUnsupported.selector);
+        hook.placeOrder(nativeKey, -tickSpacing, false, 1e18);
+
+        assertEq(address(hook).balance, seeded, "no placement should reach the hook's balance");
+        assertEq(rawOrderIdOf(nativeKey, tickSpacing, true), 0, "no sell order should exist");
+        assertEq(rawOrderIdOf(nativeKey, -tickSpacing, false), 0, "no buy order should exist");
+    }
+
+    /// @dev The library pays the native currency from the balance of the calling contract, so settling it
+    /// for anyone else would spend a balance that payer never provided.
+    function test_settle_nativeForAnotherPayer_reverts() public {
+        CurrencySettlerMock settler = new CurrencySettlerMock();
+
+        vm.expectRevert(abi.encodeWithSelector(CurrencySettler.InvalidNativePayer.selector, attacker));
+        settler.settleNative(manager, attacker, 1 ether);
+    }
+
+    function rawOrderIdOf(PoolKey memory poolKey, int24 tickLower, bool zeroForOne) internal view returns (uint232) {
+        return OrderIdLibrary.OrderId.unwrap(hook.getOrderId(poolKey, tickLower, zeroForOne));
+    }
+}


### PR DESCRIPTION
Fixes #121. `CurrencySettler.settle` pays the native currency from the balance of the calling contract while ignoring the `payer` argument, so a hook settling for someone else spends its own balance. Settling the native currency now requires `payer` to be the calling contract.

`LimitOrderHook` serves no pool holding the native currency. The placer settles the currency their order sells, which the hook cannot take from them, so an order was free to place and paid out on cancel.

`BaseCustomAccounting` and `BaseCustomCurve` now name the calling contract as the payer for the native currency, which is what they already did in effect.