### PR TITLE
ReHypothecationHook: safer JIT sizing and swap-path hardening

### DIFF
--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -10,6 +10,8 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
+import {TransientSlot} from "@openzeppelin/contracts/utils/TransientSlot.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {Position} from "@uniswap/v4-core/src/libraries/Position.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
@@ -78,9 +80,24 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     using SafeCast for *;
     using Math for uint256;
     using SafeERC20 for IERC20;
+    using TransientSlot for *;
+    using SlotDerivation for *;
 
     /// @dev The pool key for the hook. Note that the hook supports only one pool key.
     PoolKey private _poolKey;
+
+    /*
+     * @dev The ERC-7201 namespaced transient storage slot for this hook.
+     * keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ReHypothecationHook")) - 1)) & ~bytes32(uint256(0xff))
+    */
+    bytes32 private constant REHYPOTHECATION_HOOK_SLOT =
+        0x23f8264cc98f1c05acfa1795f9fb9efa795bb6c05987a0477bcc1622ab5aca00;
+
+    /// @dev The offset of the just-in-time position lower tick within {REHYPOTHECATION_HOOK_SLOT}.
+    uint256 private constant TICK_LOWER_OFFSET = 0;
+
+    /// @dev The offset of the just-in-time position upper tick within {REHYPOTHECATION_HOOK_SLOT}.
+    uint256 private constant TICK_UPPER_OFFSET = 1;
 
     /// @dev Error thrown when trying to initialize a pool that has already been initialized.
     error AlreadyInitialized();
@@ -223,8 +240,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         _transferFromSenderToHook(_poolKey.currency0, amount0, msg.sender);
         _transferFromSenderToHook(_poolKey.currency1, amount1, msg.sender);
 
-        _depositToYieldSource(_poolKey.currency0, amount0);
-        _depositToYieldSource(_poolKey.currency1, amount1);
+        // Skip zero-amount deposits, which some yield sources reject (e.g. when one side is proportionally empty)
+        if (amount0 > 0) _depositToYieldSource(_poolKey.currency0, amount0);
+        if (amount1 > 0) _depositToYieldSource(_poolKey.currency1, amount1);
 
         _mint(msg.sender, shares);
 
@@ -254,8 +272,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
 
         _burn(msg.sender, shares);
 
-        _withdrawFromYieldSource(_poolKey.currency0, amount0);
-        _withdrawFromYieldSource(_poolKey.currency1, amount1);
+        // Skip zero-amount withdrawals, which some yield sources reject (e.g. when one side is proportionally empty)
+        if (amount0 > 0) _withdrawFromYieldSource(_poolKey.currency0, amount0);
+        if (amount1 > 0) _withdrawFromYieldSource(_poolKey.currency1, amount1);
 
         _transferFromHookToSender(_poolKey.currency0, amount0, msg.sender);
         _transferFromHookToSender(_poolKey.currency1, amount1, msg.sender);
@@ -286,6 +305,10 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {
+        // Snapshot the position's tick bounds so `afterSwap` removes exactly what is added here, even if the
+        // tick getters are overridden to depend on mutable pool state that the swap then moves.
+        _snapshotActiveTicks();
+
         // Get the liquidity to be used from the amounts currently deposited in the yield sources
         uint256 liquidityToUse = _getLiquidityToUse();
         if (liquidityToUse > 0) _modifyLiquidity(liquidityToUse.toInt256());
@@ -467,6 +490,25 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     }
 
     /**
+     * @dev Snapshots the just-in-time position's tick bounds into transient storage, so the same bounds are used
+     * to add, read and remove the position across a swap. Called at the start of `beforeSwap`.
+     */
+    function _snapshotActiveTicks() private {
+        REHYPOTHECATION_HOOK_SLOT.offset(TICK_LOWER_OFFSET).asInt256().tstore(getTickLower());
+        REHYPOTHECATION_HOOK_SLOT.offset(TICK_UPPER_OFFSET).asInt256().tstore(getTickUpper());
+    }
+
+    /// @dev The lower tick of the just-in-time position snapshotted for the current swap.
+    function _activeTickLower() private view returns (int24) {
+        return int24(REHYPOTHECATION_HOOK_SLOT.offset(TICK_LOWER_OFFSET).asInt256().tload());
+    }
+
+    /// @dev The upper tick of the just-in-time position snapshotted for the current swap.
+    function _activeTickUpper() private view returns (int24) {
+        return int24(REHYPOTHECATION_HOOK_SLOT.offset(TICK_UPPER_OFFSET).asInt256().tload());
+    }
+
+    /**
      * @dev Retrieves the current `liquidity` of the hook owned liquidity position in the `_poolKey` pool.
      *
      * NOTE: Given that just-in-time liquidity provisioning is performed, this function will only return non-zero values
@@ -475,7 +517,8 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * {_getAmountInYieldSource}.
      */
     function _getHookPositionLiquidity() internal view virtual returns (uint128 liquidity) {
-        bytes32 positionKey = Position.calculatePositionKey(address(this), getTickLower(), getTickUpper(), bytes32(0));
+        bytes32 positionKey =
+            Position.calculatePositionKey(address(this), _activeTickLower(), _activeTickUpper(), bytes32(0));
         return poolManager.getPositionLiquidity(_poolKey.toId(), positionKey);
     }
 
@@ -498,7 +541,8 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     }
 
     /**
-     * @dev Modifies the hook's liquidity position in the pool.
+     * @dev Modifies the hook's liquidity position in the pool, at the tick bounds snapshotted for the current
+     * swap (see {_snapshotActiveTicks}).
      *
      * Positive liquidityDelta adds liquidity, while negative removes it.
      */
@@ -506,7 +550,10 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         (delta,) = poolManager.modifyLiquidity(
             _poolKey,
             ModifyLiquidityParams({
-                tickLower: getTickLower(), tickUpper: getTickUpper(), liquidityDelta: liquidityDelta, salt: bytes32(0)
+                tickLower: _activeTickLower(),
+                tickUpper: _activeTickUpper(),
+                liquidityDelta: liquidityDelta,
+                salt: bytes32(0)
             }),
             ""
         );

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -439,8 +439,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /**
      * @dev Calculates the `liquidity` to be provided just-in-time for incoming swaps.
      *
-     * By default, returns the maximum liquidity that can be provided given the current balances
-     * of the hook in the yield sources.
+     * By default, returns the maximum liquidity that can be provided given the balances the hook can
+     * currently withdraw from the yield sources (see {_getMaxWithdrawFromYieldSource}), so the position
+     * removed in `afterSwap` never exceeds what the yield sources can return in the same transaction.
      *
      * Since the internal pool price (ratio of currency0 to currency1) must be preserved for providing
      * liquidity to the single hook-owned position range, not necessarily all the assets in the yield
@@ -460,8 +461,8 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
             currentSqrtPriceX96,
             TickMath.getSqrtPriceAtTick(getTickLower()),
             TickMath.getSqrtPriceAtTick(getTickUpper()),
-            _getAmountInYieldSource(_poolKey.currency0),
-            _getAmountInYieldSource(_poolKey.currency1)
+            _getMaxWithdrawFromYieldSource(_poolKey.currency0),
+            _getMaxWithdrawFromYieldSource(_poolKey.currency1)
         );
     }
 
@@ -565,6 +566,20 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      *  ERC-4626 Vaults, or any custom DeFi protocol interface, optionally handling native currency.
      */
     function _getAmountInYieldSource(Currency currency) internal view virtual returns (uint256 amount);
+
+    /**
+     * @dev Returns the maximum `amount` of `currency` that can currently be withdrawn from its yield source.
+     *
+     * Used to size the just-in-time liquidity provided during swaps, so the hook never provisions more than it
+     * can withdraw back in the same transaction. Share pricing instead uses {_getAmountInYieldSource}, the full
+     * reported balance.
+     *
+     * Defaults to {_getAmountInYieldSource}. Override for yield sources whose immediately-withdrawable amount can
+     * be below the reported balance, such as ERC-4626 `maxWithdraw`, or capped, gated or fee-charging sources.
+     */
+    function _getMaxWithdrawFromYieldSource(Currency currency) internal view virtual returns (uint256) {
+        return _getAmountInYieldSource(currency);
+    }
 
     /**
      * Set the hooks permissions, specifically `beforeInitialize`, `beforeSwap`, `afterSwap`.

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -305,8 +305,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {
-        // Snapshot the position's tick bounds so `afterSwap` removes exactly what is added here, even if the
-        // tick getters are overridden to depend on mutable pool state that the swap then moves.
+        // Snapshot the position's tick bounds so `afterSwap` removes exactly what is added here.
         _snapshotActiveTicks();
 
         // Get the liquidity to be used from the amounts currently deposited in the yield sources

--- a/src/mocks/general/ReHypothecationERC4626Mock.sol
+++ b/src/mocks/general/ReHypothecationERC4626Mock.sol
@@ -87,6 +87,11 @@ contract ReHypothecationERC4626Mock is ReHypothecationHook {
         return yieldSource.convertToAssets(yieldSourceShares);
     }
 
+    /// @inheritdoc ReHypothecationHook
+    function _getMaxWithdrawFromYieldSource(Currency currency) internal view virtual override returns (uint256) {
+        return IERC4626(getCurrencyYieldSource(currency)).maxWithdraw(address(this));
+    }
+
     /// @dev Override to disable native currency, which is not supported by ERC-4626 yield sources.
     receive() external payable override {
         revert UnsupportedCurrency();
@@ -95,6 +100,16 @@ contract ReHypothecationERC4626Mock is ReHypothecationHook {
     /// @dev Exposed internal function for testing
     function getAmountInYieldSource(Currency currency) public view returns (uint256) {
         return _getAmountInYieldSource(currency);
+    }
+
+    /// @dev Exposed internal function for testing
+    function getMaxWithdrawFromYieldSource(Currency currency) public view returns (uint256) {
+        return _getMaxWithdrawFromYieldSource(currency);
+    }
+
+    /// @dev Exposed internal function for testing
+    function getLiquidityToUse() public view returns (uint256) {
+        return _getLiquidityToUse();
     }
 
     /// @dev Exposed internal function for testing

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.24;
 
 // External imports
-import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
@@ -26,6 +25,23 @@ import {HookTest} from "../utils/HookTest.sol";
 import {BalanceDeltaAssertions} from "../utils/BalanceDeltaAssertions.sol";
 import {BaseHook} from "../../src/base/BaseHook.sol";
 
+/// @dev An ERC-4626 yield source whose `maxWithdraw` can be capped below its balance, to model gated or
+/// illiquid vaults when testing the withdrawable-based JIT sizing. Uncapped, it behaves like its parent.
+contract CappedERC4626Mock is ERC4626YieldSourceMock {
+    uint256 private _cap = type(uint256).max;
+
+    constructor(IERC20 token) ERC4626YieldSourceMock(token) {}
+
+    function setCap(uint256 cap) external {
+        _cap = cap;
+    }
+
+    function maxWithdraw(address owner) public view override returns (uint256) {
+        uint256 unconstrained = super.maxWithdraw(owner);
+        return unconstrained < _cap ? unconstrained : _cap;
+    }
+}
+
 contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     using StateLibrary for IPoolManager;
     using SafeCast for *;
@@ -33,8 +49,8 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
 
     ReHypothecationERC4626Mock hook;
 
-    IERC4626 yieldSource0;
-    IERC4626 yieldSource1;
+    CappedERC4626Mock yieldSource0;
+    CappedERC4626Mock yieldSource1;
 
     PoolKey noHookKey;
 
@@ -54,8 +70,8 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         deployFreshManagerAndRouters();
         deployMintAndApprove2Currencies();
 
-        yieldSource0 = IERC4626(new ERC4626YieldSourceMock(IERC20(Currency.unwrap(currency0))));
-        yieldSource1 = IERC4626(new ERC4626YieldSourceMock(IERC20(Currency.unwrap(currency1))));
+        yieldSource0 = new CappedERC4626Mock(IERC20(Currency.unwrap(currency0)));
+        yieldSource1 = new CappedERC4626Mock(IERC20(Currency.unwrap(currency1)));
 
         hook = ReHypothecationERC4626Mock(
             payable(address(
@@ -690,5 +706,25 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         // Hooked
         BalanceDelta hookedRemoveDelta = hook.removeReHypothecatedLiquidity(seedShares);
         assertApproxEqAbs(hookedRemoveDelta, noHookRemoveDelta, TOL, "hookedRemoveDelta !~= noHookRemoveDelta");
+    }
+
+    // -- JIT SIZING -- //
+
+    function test_getLiquidityToUse_sizedByWithdrawableBalance() public {
+        _seed();
+
+        uint256 liqFull = hook.getLiquidityToUse();
+        assertGt(liqFull, 0, "sanity: liquidity should be non-zero");
+
+        // Cap currency0 withdrawals well below the seeded balance.
+        uint256 cap = SEED / 1000;
+        yieldSource0.setCap(cap);
+
+        // The withdrawable amount now reflects the cap, and is below the reported balance...
+        assertEq(hook.getMaxWithdrawFromYieldSource(currency0), cap, "max withdraw != cap");
+        assertLt(cap, hook.getAmountInYieldSource(currency0), "cap should be below the reported balance");
+
+        // ...so the just-in-time liquidity is sized down accordingly, never above what can be withdrawn back.
+        assertLt(hook.getLiquidityToUse(), liqFull, "capped liquidity should be lower");
     }
 }

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -42,6 +42,46 @@ contract CappedERC4626Mock is ERC4626YieldSourceMock {
     }
 }
 
+/// @dev An ERC-4626 yield source that reverts on zero-amount deposits/withdrawals, like several real lending
+/// protocols, to test that the hook skips zero-amount yield-source calls.
+contract RevertOnZeroERC4626Mock is ERC4626YieldSourceMock {
+    error ZeroAmount();
+
+    constructor(IERC20 token) ERC4626YieldSourceMock(token) {}
+
+    function deposit(uint256 assets, address receiver) public override returns (uint256) {
+        if (assets == 0) revert ZeroAmount();
+        return super.deposit(assets, receiver);
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner) public override returns (uint256) {
+        if (assets == 0) revert ZeroAmount();
+        return super.withdraw(assets, receiver, owner);
+    }
+}
+
+/// @dev A rehypothecation hook whose position range tracks the current pool tick, so the range shifts as a swap
+/// moves the price. Used to test that the position's tick bounds are snapshotted across a swap.
+contract DynamicTickReHypothecationMock is ReHypothecationERC4626Mock {
+    using StateLibrary for IPoolManager;
+
+    constructor(IPoolManager pm, address ys0, address ys1) ReHypothecationERC4626Mock(pm, ys0, ys1) {}
+
+    function getTickLower() public view override returns (int24) {
+        return _center() - 10 * getPoolKey().tickSpacing;
+    }
+
+    function getTickUpper() public view override returns (int24) {
+        return _center() + 10 * getPoolKey().tickSpacing;
+    }
+
+    function _center() private view returns (int24) {
+        (, int24 tick,,) = poolManager.getSlot0(getPoolKey().toId());
+        int24 spacing = getPoolKey().tickSpacing;
+        return (tick / spacing) * spacing;
+    }
+}
+
 contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     using StateLibrary for IPoolManager;
     using SafeCast for *;
@@ -133,6 +173,15 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
 
     function _seed() internal returns (uint256 shares) {
         (shares,) = hook.seedLiquidity(SEED, SEED);
+    }
+
+    /// @dev A distinct hook address carrying the required permission flag bits, offset by `nudge`.
+    function _flagAddr(uint160 nudge) internal pure returns (address) {
+        uint160 flags = uint160(
+            Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG
+                | Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG
+        );
+        return address(flags + nudge);
     }
 
     // -- INITIALIZING -- //
@@ -726,5 +775,65 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
 
         // ...so the just-in-time liquidity is sized down accordingly, never above what can be withdrawn back.
         assertLt(hook.getLiquidityToUse(), liqFull, "capped liquidity should be lower");
+    }
+
+    // -- ZERO-AMOUNT YIELD-SOURCE CALLS -- //
+
+    function test_remove_zeroLeg_skipsZeroYieldSourceWithdraw() public {
+        // currency0's yield source reverts on zero-amount withdrawals.
+        RevertOnZeroERC4626Mock ys0r = new RevertOnZeroERC4626Mock(IERC20(Currency.unwrap(currency0)));
+        CappedERC4626Mock ys1r = new CappedERC4626Mock(IERC20(Currency.unwrap(currency1)));
+        address hookAddr = _flagAddr(0x30000000000000000000000000000000);
+        deployCodeTo(
+            "src/mocks/general/ReHypothecationERC4626Mock.sol:ReHypothecationERC4626Mock",
+            abi.encode(address(manager), address(ys0r), address(ys1r)),
+            hookAddr
+        );
+        ReHypothecationERC4626Mock h = ReHypothecationERC4626Mock(payable(hookAddr));
+        initPool(currency0, currency1, IHooks(hookAddr), fee, SQRT_PRICE_1_1);
+
+        IERC20(Currency.unwrap(currency0)).approve(hookAddr, type(uint256).max);
+        IERC20(Currency.unwrap(currency1)).approve(hookAddr, type(uint256).max);
+        h.seedLiquidity(SEED, SEED);
+
+        // Drain currency0's yield source so a proportional redeem prices its leg to zero (rounds down).
+        h.burnYieldSourcesBalance(currency0, h.getAmountInYieldSource(currency0));
+
+        uint256 smallShares = 1e6;
+        (uint256 amount0, uint256 amount1) = h.previewRedeem(smallShares);
+        assertEq(amount0, 0, "currency0 leg should redeem to zero");
+        assertGt(amount1, 0, "currency1 leg should be non-zero");
+
+        // Must not revert: the zero currency0 withdrawal is skipped instead of hitting the reverting yield source.
+        h.removeReHypothecatedLiquidity(smallShares);
+    }
+
+    // -- JIT TICK SNAPSHOT -- //
+
+    function test_swap_dynamicTicks_snapshotsRangeAcrossSwap() public {
+        CappedERC4626Mock ys0d = new CappedERC4626Mock(IERC20(Currency.unwrap(currency0)));
+        CappedERC4626Mock ys1d = new CappedERC4626Mock(IERC20(Currency.unwrap(currency1)));
+        address hookAddr = _flagAddr(0x40000000000000000000000000000000);
+        deployCodeTo(
+            "test/general/ReHypothecationHookERC4626.t.sol:DynamicTickReHypothecationMock",
+            abi.encode(address(manager), address(ys0d), address(ys1d)),
+            hookAddr
+        );
+        DynamicTickReHypothecationMock h = DynamicTickReHypothecationMock(payable(hookAddr));
+        (PoolKey memory dynKey,) = initPool(currency0, currency1, IHooks(hookAddr), fee, SQRT_PRICE_1_1);
+
+        IERC20(Currency.unwrap(currency0)).approve(hookAddr, type(uint256).max);
+        IERC20(Currency.unwrap(currency1)).approve(hookAddr, type(uint256).max);
+        h.seedLiquidity(SEED, SEED);
+
+        (, int24 tickBefore,,) = StateLibrary.getSlot0(manager, dynKey.toId());
+
+        // A large exact-input swap moves the tick, so the dynamic range would shift between beforeSwap and
+        // afterSwap. With the range snapshotted, afterSwap removes exactly what beforeSwap added and the swap
+        // succeeds; without it the position would be orphaned and the swap would revert.
+        swap(dynKey, true, -5e17, ZERO_BYTES);
+
+        (, int24 tickAfter,,) = StateLibrary.getSlot0(manager, dynKey.toId());
+        assertTrue(tickBefore != tickAfter, "swap should move the tick, exercising the range shift");
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #151 and must be merged **after** it. The base of this PR is the `rehypothecation-refactor` branch, so it only shows the commits added on top of #151; once #151 lands on `master`, retarget this PR to `master`.

Continues the `ReHypothecationHook` refactor with three self-contained robustness fixes on top of #151.

## Size just-in-time liquidity by the withdrawable balance

Adds `_getMaxWithdrawFromYieldSource`, the amount currently withdrawable from a yield source (defaulting to `_getAmountInYieldSource`), and sizes the JIT position off it rather than the gross reported balance, so the position removed in `afterSwap` never exceeds what the yield sources can return in the same transaction. Share pricing keeps using the gross balance. The ERC-4626 reference mock overrides it to `maxWithdraw`.

## Snapshot the JIT position's tick bounds across a swap

`beforeSwap` now snapshots the position's tick bounds into transient storage and `afterSwap` reuses them, so the position removed matches the one added even when `getTickLower`/`getTickUpper` are overridden to depend on mutable pool state that the swap moves. Default (constant) bounds are unaffected.

## Skip zero-amount yield-source calls

`add`/`remove` skip a zero-amount deposit/withdrawal, which some yield sources reject. With the current pricing this is only reachable on `remove` (a proportionally-empty leg rounds down to zero on redeem); the `add` guard remains as defense against overridden pricing.

## Tests

Adds coverage for withdrawable-based sizing (a capped vault), the tick snapshot (a hook whose range tracks the current tick, swapped so the range shifts), and zero-amount skipping (a yield source that reverts on zero-amount ops). Full suite passes (339 tests).