### PR TITLE
ReHypothecationHook: settlement reentrancy lock and pool-key validation

### DIFF
--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -99,6 +99,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /// @dev The offset of the just-in-time position upper tick within {REHYPOTHECATION_HOOK_SLOT}.
     uint256 private constant TICK_UPPER_OFFSET = 1;
 
+    /// @dev The offset of the swap-cycle lock flag within {REHYPOTHECATION_HOOK_SLOT}.
+    uint256 private constant SWAP_CYCLE_OFFSET = 2;
+
     /// @dev Error thrown when trying to initialize a pool that has already been initialized.
     error AlreadyInitialized();
 
@@ -125,6 +128,10 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
 
     /// @dev Error thrown when a seed would mint fewer than the minimum safe initial `shares`, given `minShares`.
     error InsufficientSeed(uint256 shares, uint256 minShares);
+
+    /// @dev Error thrown when a liquidity operation and a swap cycle would overlap, to prevent reentrancy
+    /// across the just-in-time settlement.
+    error Locked();
 
     /**
      * @dev Emitted when a `sender` adds rehypothecated `shares` to the `poolKey` pool,
@@ -153,12 +160,25 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * @dev Initialize the hook's `poolKey` pool. The key stored by the hook is unique and
      * should not be modified so that it can safely be used across the hook's lifecycle.
      * Note that the hook supports only one pool key.
+     *
+     * WARNING: The first initialization permanently binds the hook to the pool it observes. Since pool
+     * initialization is permissionless, a third party could front-run and bind the hook to an unintended pool.
+     * Deployers should initialize the pool atomically with the hook's deployment to avoid this, and may
+     * override {_validatePoolKey} to enforce the expected pool key.
      */
     function _beforeInitialize(address, PoolKey calldata key, uint160) internal virtual override returns (bytes4) {
         if (address(_poolKey.hooks) != address(0)) revert AlreadyInitialized();
+        _validatePoolKey(key);
         _poolKey = key;
         return this.beforeInitialize.selector;
     }
+
+    /**
+     * @dev Validates the `key` the hook is about to bind to on first initialization. Defaults to accepting any
+     * key; override to restrict the hook to an expected pool (e.g. specific currencies, fee or tick spacing)
+     * and defend against front-run binding. See {_beforeInitialize}.
+     */
+    function _validatePoolKey(PoolKey calldata key) internal view virtual {}
 
     /**
      * @dev Seeds the pool with its first liquidity, depositing `amount0` of `currency0` and `amount1` of
@@ -190,6 +210,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         returns (uint256 shares, BalanceDelta delta)
     {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
+        if (_inSwapCycle()) revert Locked();
         if (totalSupply() != 0) revert AlreadySeeded();
 
         shares = Math.sqrt(amount0 * amount1);
@@ -232,6 +253,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         returns (BalanceDelta delta)
     {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
+        if (_inSwapCycle()) revert Locked();
         if (totalSupply() == 0) revert NotSeeded();
         if (shares == 0) revert ZeroShares();
 
@@ -266,6 +288,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      */
     function removeReHypothecatedLiquidity(uint256 shares) public virtual nonReentrant returns (BalanceDelta delta) {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
+        if (_inSwapCycle()) revert Locked();
         if (shares == 0) revert ZeroShares();
 
         (uint256 amount0, uint256 amount1) = previewRedeem(shares);
@@ -305,6 +328,11 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {
+        // Lock the swap cycle: block liquidity operations from reentering mid-settlement, and block a swap
+        // from running inside a liquidity operation or another swap cycle. Cleared at the end of `_afterSwap`.
+        if (_reentrancyGuardEntered() || _inSwapCycle()) revert Locked();
+        _setSwapCycle(true);
+
         // Snapshot the position's tick bounds so `afterSwap` removes exactly what is added here.
         _snapshotActiveTicks();
 
@@ -342,6 +370,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
             _resolveHookDelta(key.currency0);
             _resolveHookDelta(key.currency1);
         }
+
+        // Unlock the swap cycle once settlement (and its external yield-source calls) is complete.
+        _setSwapCycle(false);
 
         return (this.afterSwap.selector, 0);
     }
@@ -505,6 +536,16 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /// @dev The upper tick of the just-in-time position snapshotted for the current swap.
     function _activeTickUpper() private view returns (int24) {
         return int24(REHYPOTHECATION_HOOK_SLOT.offset(TICK_UPPER_OFFSET).asInt256().tload());
+    }
+
+    /// @dev Sets whether a swap cycle (`beforeSwap` through `afterSwap`) is currently in progress.
+    function _setSwapCycle(bool active) private {
+        REHYPOTHECATION_HOOK_SLOT.offset(SWAP_CYCLE_OFFSET).asBoolean().tstore(active);
+    }
+
+    /// @dev Whether a swap cycle is currently in progress.
+    function _inSwapCycle() private view returns (bool) {
+        return REHYPOTHECATION_HOOK_SLOT.offset(SWAP_CYCLE_OFFSET).asBoolean().tload();
     }
 
     /**

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -100,8 +100,8 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /// @dev The offset of the just-in-time position upper tick within {REHYPOTHECATION_HOOK_SLOT}.
     uint256 private constant TICK_UPPER_OFFSET = 1;
 
-    /// @dev The offset of the swap-cycle lock flag within {REHYPOTHECATION_HOOK_SLOT}.
-    uint256 private constant SWAP_CYCLE_OFFSET = 2;
+    /// @dev The offset of the JIT lock flag within {REHYPOTHECATION_HOOK_SLOT}.
+    uint256 private constant JIT_LOCK_OFFSET = 2;
 
     /// @dev Error thrown when trying to initialize a pool that has already been initialized.
     error AlreadyInitialized();
@@ -130,9 +130,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /// @dev Error thrown when a seed would mint fewer than the minimum safe initial `shares`, given `minShares`.
     error InsufficientSeed(uint256 shares, uint256 minShares);
 
-    /// @dev Error thrown when a liquidity operation and a swap cycle would overlap, to prevent reentrancy
-    /// across the just-in-time settlement.
-    error Locked();
+    /// @dev Error thrown when a liquidity operation and the just-in-time settlement would overlap,
+    /// to prevent reentrancy across the JIT lock.
+    error JITLocked();
 
     /**
      * @dev Emitted when a `sender` adds rehypothecated `shares` to the `poolKey` pool,
@@ -162,21 +162,9 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * should not be modified so that it can safely be used across the hook's lifecycle.
      * Note that the hook supports only one pool key.
      *
-     * WARNING: The first initialization permanently binds the hook to the pool it observes, and pool
-     * initialization is permissionless. A third party can front-run it and bind the hook to an unintended pool.
-     * Consider initializing the pool atomically with the hook's deployment. To reject an unexpected key on-chain,
-     * override this function:
-     *
-     * ```solidity
-     * function _beforeInitialize(address sender, PoolKey calldata key, uint160 sqrtPriceX96)
-     *     internal
-     *     override
-     *     returns (bytes4)
-     * {
-     *     if (key.fee != EXPECTED_FEE) revert WrongPool();
-     *     return super._beforeInitialize(sender, key, sqrtPriceX96);
-     * }
-     * ```
+     * WARNING: Pool initialization is permissionless and permanently binds the hook to the first key it sees,
+     * so a third party can front-run it with an unintended pool. Initialize the pool atomically with the hook's
+     * deployment, or override this function to reject an unexpected key.
      */
     function _beforeInitialize(address, PoolKey calldata key, uint160) internal virtual override returns (bytes4) {
         if (address(_poolKey.hooks) != address(0)) revert AlreadyInitialized();
@@ -187,26 +175,22 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
     /**
      * @dev Seeds the pool with its first liquidity, depositing `amount0` of `currency0` and `amount1` of
      * `currency1` into the yield sources and minting `sqrt(amount0 * amount1)` shares to the caller, in a
-     * UniswapV2 like fashion. The deposited amounts set the pool's initial ratio.
+     * UniswapV2 like fashion. The deposited amounts set the ratio at which {addReHypothecatedLiquidity}
+     * prices every later addition.
      *
      * Callable permissionlessly whenever the pool has no outstanding shares: at genesis, or to revive the pool
-     * after a full withdrawal (since {addReHypothecatedLiquidity} reverts once the supply is zero). Subsequent
-     * liquidity is added through {addReHypothecatedLiquidity}, which prices shares proportionally to the seeded balances.
-     *
-     * The minted shares must be at least `100 * 10 ** _decimalsOffset()`, so the supply dominates the
-     * virtual-shares offset used in {_shareToAmount} and the share price cannot be meaningfully inflated.
+     * after a full withdrawal. The minted shares must be at least `100 * 10 ** _decimalsOffset()`, so the supply
+     * dominates the virtual-shares offset used in {_shareToAmount} and the share price cannot be inflated.
      *
      * Returns the `shares` minted and a balance `delta` representing the assets deposited into the hook.
      *
      * NOTE: The amounts should be provided close to the pool's current price, otherwise part of the seeded
      * liquidity may sit idle until swaps rebalance it. See {_getLiquidityToUse}.
      *
-     * WARNING: The deposited amounts set the ratio at which every later liquidity addition is priced, and
-     * seeding is permissionless. A third party can front-run the intended seed with a heavily skewed ratio.
-     * Since {_getLiquidityToUse} is bounded by the scarcer side, the hook is then left with negligible usable
-     * liquidity and cannot serve swaps. Deposited assets stay redeemable, and seeding reopens once the supply
-     * returns to zero. Consider seeding atomically with pool initialization, or overriding this function to
-     * restrict the caller.
+     * WARNING: A third party can front-run the intended seed with a heavily skewed ratio. Since
+     * {_getLiquidityToUse} is bounded by the scarcer side, the hook is then left with negligible usable liquidity
+     * and cannot serve swaps. Deposited assets stay redeemable, and seeding reopens once the supply returns to
+     * zero. Consider seeding atomically with pool initialization, or overriding this function to restrict the caller.
      *
      * Requirements:
      * - Pool must be initialized
@@ -222,7 +206,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         returns (uint256 shares, BalanceDelta delta)
     {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
-        if (_inSwapCycle()) revert Locked();
+        if (_isJITLocked()) revert JITLocked();
         if (totalSupply() != 0) revert AlreadySeeded();
 
         shares = Math.sqrt(amount0 * amount1);
@@ -265,7 +249,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         returns (BalanceDelta delta)
     {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
-        if (_inSwapCycle()) revert Locked();
+        if (_isJITLocked()) revert JITLocked();
         if (totalSupply() == 0) revert NotSeeded();
         if (shares == 0) revert ZeroShares();
 
@@ -300,7 +284,7 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      */
     function removeReHypothecatedLiquidity(uint256 shares) public virtual nonReentrant returns (BalanceDelta delta) {
         if (address(_poolKey.hooks) == address(0)) revert NotInitialized();
-        if (_inSwapCycle()) revert Locked();
+        if (_isJITLocked()) revert JITLocked();
         if (shares == 0) revert ZeroShares();
 
         (uint256 amount0, uint256 amount1) = previewRedeem(shares);
@@ -340,10 +324,10 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {
-        // Lock the swap cycle: block liquidity operations from reentering mid-settlement, and block a swap
-        // from running inside a liquidity operation or another swap cycle. Cleared at the end of `_afterSwap`.
-        if (_reentrancyGuardEntered() || _inSwapCycle()) revert Locked();
-        _setSwapCycle(true);
+        // Take the JIT lock: block liquidity operations from reentering mid-settlement, and block a swap
+        // from running inside a liquidity operation or another swap. Released at the end of `_afterSwap`.
+        if (_reentrancyGuardEntered() || _isJITLocked()) revert JITLocked();
+        _setJITLocked(true);
 
         // Snapshot the position's tick bounds so `afterSwap` removes exactly what is added here.
         _snapshotActiveTicks();
@@ -383,8 +367,8 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
             _resolveHookDelta(key.currency1);
         }
 
-        // Unlock the swap cycle once settlement (and its external yield-source calls) is complete.
-        _setSwapCycle(false);
+        // Release the JIT lock once settlement (and its external yield-source calls) is complete.
+        _setJITLocked(false);
 
         return (this.afterSwap.selector, 0);
     }
@@ -550,14 +534,14 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
         return int24(REHYPOTHECATION_HOOK_SLOT.offset(TICK_UPPER_OFFSET).asInt256().tload());
     }
 
-    /// @dev Sets whether a swap cycle (`beforeSwap` through `afterSwap`) is currently in progress.
-    function _setSwapCycle(bool active) private {
-        REHYPOTHECATION_HOOK_SLOT.offset(SWAP_CYCLE_OFFSET).asBoolean().tstore(active);
+    /// @dev Sets whether the JIT lock (`beforeSwap` through `afterSwap`) is held.
+    function _setJITLocked(bool active) private {
+        REHYPOTHECATION_HOOK_SLOT.offset(JIT_LOCK_OFFSET).asBoolean().tstore(active);
     }
 
-    /// @dev Whether a swap cycle is currently in progress.
-    function _inSwapCycle() private view returns (bool) {
-        return REHYPOTHECATION_HOOK_SLOT.offset(SWAP_CYCLE_OFFSET).asBoolean().tload();
+    /// @dev Whether the JIT lock is currently held.
+    function _isJITLocked() private view returns (bool) {
+        return REHYPOTHECATION_HOOK_SLOT.offset(JIT_LOCK_OFFSET).asBoolean().tload();
     }
 
     /**

--- a/src/general/ReHypothecationHook.sol
+++ b/src/general/ReHypothecationHook.sol
@@ -162,24 +162,27 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      * should not be modified so that it can safely be used across the hook's lifecycle.
      * Note that the hook supports only one pool key.
      *
-     * WARNING: The first initialization permanently binds the hook to the pool it observes. Since pool
-     * initialization is permissionless, a third party could front-run and bind the hook to an unintended pool.
-     * Deployers should initialize the pool atomically with the hook's deployment to avoid this, and may
-     * override {_validatePoolKey} to enforce the expected pool key.
+     * WARNING: The first initialization permanently binds the hook to the pool it observes, and pool
+     * initialization is permissionless. A third party can front-run it and bind the hook to an unintended pool.
+     * Consider initializing the pool atomically with the hook's deployment. To reject an unexpected key on-chain,
+     * override this function:
+     *
+     * ```solidity
+     * function _beforeInitialize(address sender, PoolKey calldata key, uint160 sqrtPriceX96)
+     *     internal
+     *     override
+     *     returns (bytes4)
+     * {
+     *     if (key.fee != EXPECTED_FEE) revert WrongPool();
+     *     return super._beforeInitialize(sender, key, sqrtPriceX96);
+     * }
+     * ```
      */
     function _beforeInitialize(address, PoolKey calldata key, uint160) internal virtual override returns (bytes4) {
         if (address(_poolKey.hooks) != address(0)) revert AlreadyInitialized();
-        _validatePoolKey(key);
         _poolKey = key;
         return this.beforeInitialize.selector;
     }
-
-    /**
-     * @dev Validates the `key` the hook is about to bind to on first initialization. Defaults to accepting any
-     * key; override to restrict the hook to an expected pool (e.g. specific currencies, fee or tick spacing)
-     * and defend against front-run binding. See {_beforeInitialize}.
-     */
-    function _validatePoolKey(PoolKey calldata key) internal view virtual {}
 
     /**
      * @dev Seeds the pool with its first liquidity, depositing `amount0` of `currency0` and `amount1` of
@@ -197,6 +200,13 @@ abstract contract ReHypothecationHook is BaseHook, ERC20, ReentrancyGuardTransie
      *
      * NOTE: The amounts should be provided close to the pool's current price, otherwise part of the seeded
      * liquidity may sit idle until swaps rebalance it. See {_getLiquidityToUse}.
+     *
+     * WARNING: The deposited amounts set the ratio at which every later liquidity addition is priced, and
+     * seeding is permissionless. A third party can front-run the intended seed with a heavily skewed ratio.
+     * Since {_getLiquidityToUse} is bounded by the scarcer side, the hook is then left with negligible usable
+     * liquidity and cannot serve swaps. Deposited assets stay redeemable, and seeding reopens once the supply
+     * returns to zero. Consider seeding atomically with pool initialization, or overriding this function to
+     * restrict the caller.
      *
      * Requirements:
      * - Pool must be initialized

--- a/src/mocks/general/ReHypothecationERC4626Mock.sol
+++ b/src/mocks/general/ReHypothecationERC4626Mock.sol
@@ -50,6 +50,7 @@ contract ReHypothecationERC4626Mock is ReHypothecationHook {
     /// @dev Override to disable native currency, which is not supported by ERC-4626 yield sources.
     function _beforeInitialize(address sender, PoolKey calldata key, uint160 sqrtPriceX96)
         internal
+        virtual
         override
         returns (bytes4)
     {

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -110,14 +110,19 @@ contract ReentrantYieldSourceMock is ERC4626YieldSourceMock {
     }
 }
 
-/// @dev A hook that only accepts a pool with a specific fee, exercising the {_validatePoolKey} override.
+/// @dev A hook that only accepts a pool with a specific fee, exercising the `_beforeInitialize` override.
 contract ValidatingReHypothecationMock is ReHypothecationERC4626Mock {
     error WrongPool();
 
     constructor(IPoolManager pm, address ys0, address ys1) ReHypothecationERC4626Mock(pm, ys0, ys1) {}
 
-    function _validatePoolKey(PoolKey calldata key) internal pure override {
+    function _beforeInitialize(address sender, PoolKey calldata key, uint160 sqrtPriceX96)
+        internal
+        override
+        returns (bytes4)
+    {
         if (key.fee != 3000) revert WrongPool();
+        return super._beforeInitialize(sender, key, sqrtPriceX96);
     }
 }
 
@@ -910,7 +915,7 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
 
     // -- POOL KEY VALIDATION -- //
 
-    function test_validatePoolKey_override_gatesBinding() public {
+    function test_beforeInitialize_override_gatesBinding() public {
         CappedERC4626Mock ys0v = new CappedERC4626Mock(IERC20(Currency.unwrap(currency0)));
         CappedERC4626Mock ys1v = new CappedERC4626Mock(IERC20(Currency.unwrap(currency1)));
         address hookAddr = _flagAddr(0x60000000000000000000000000000000);

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -908,8 +908,8 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
         assertTrue(ys1m.reentered(), "reentrancy should have been attempted");
         assertEq(
             ys1m.reentryRevertReason(),
-            abi.encodeWithSelector(ReHypothecationHook.Locked.selector),
-            "reentrant liquidity op should be blocked by the swap-cycle lock"
+            abi.encodeWithSelector(ReHypothecationHook.JITLocked.selector),
+            "reentrant liquidity op should be blocked by the JIT lock"
         );
     }
 

--- a/test/general/ReHypothecationHookERC4626.t.sol
+++ b/test/general/ReHypothecationHookERC4626.t.sol
@@ -82,6 +82,45 @@ contract DynamicTickReHypothecationMock is ReHypothecationERC4626Mock {
     }
 }
 
+/// @dev A yield source that attempts to reenter the hook's `removeReHypothecatedLiquidity` on withdraw, to
+/// test that liquidity operations are locked during a swap's settlement.
+contract ReentrantYieldSourceMock is ERC4626YieldSourceMock {
+    ReHypothecationHook public hook;
+    bool public reentered;
+    bytes public reentryRevertReason;
+    bool private _armed;
+
+    constructor(IERC20 token) ERC4626YieldSourceMock(token) {}
+
+    function arm(ReHypothecationHook hook_) external {
+        hook = hook_;
+        _armed = true;
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner) public override returns (uint256) {
+        if (_armed) {
+            _armed = false;
+            reentered = true;
+            try hook.removeReHypothecatedLiquidity(1) {}
+            catch (bytes memory reason) {
+                reentryRevertReason = reason;
+            }
+        }
+        return super.withdraw(assets, receiver, owner);
+    }
+}
+
+/// @dev A hook that only accepts a pool with a specific fee, exercising the {_validatePoolKey} override.
+contract ValidatingReHypothecationMock is ReHypothecationERC4626Mock {
+    error WrongPool();
+
+    constructor(IPoolManager pm, address ys0, address ys1) ReHypothecationERC4626Mock(pm, ys0, ys1) {}
+
+    function _validatePoolKey(PoolKey calldata key) internal pure override {
+        if (key.fee != 3000) revert WrongPool();
+    }
+}
+
 contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
     using StateLibrary for IPoolManager;
     using SafeCast for *;
@@ -835,5 +874,66 @@ contract ReHypothecationHookERC4626Test is HookTest, BalanceDeltaAssertions {
 
         (, int24 tickAfter,,) = StateLibrary.getSlot0(manager, dynKey.toId());
         assertTrue(tickBefore != tickAfter, "swap should move the tick, exercising the range shift");
+    }
+
+    // -- SETTLEMENT REENTRANCY -- //
+
+    function test_afterSwap_liquidityReentrancy_blocked() public {
+        // currency1's yield source reenters removeReHypothecatedLiquidity during afterSwap's withdrawal.
+        CappedERC4626Mock ys0m = new CappedERC4626Mock(IERC20(Currency.unwrap(currency0)));
+        ReentrantYieldSourceMock ys1m = new ReentrantYieldSourceMock(IERC20(Currency.unwrap(currency1)));
+        address hookAddr = _flagAddr(0x50000000000000000000000000000000);
+        deployCodeTo(
+            "src/mocks/general/ReHypothecationERC4626Mock.sol:ReHypothecationERC4626Mock",
+            abi.encode(address(manager), address(ys0m), address(ys1m)),
+            hookAddr
+        );
+        ReHypothecationERC4626Mock h = ReHypothecationERC4626Mock(payable(hookAddr));
+        (PoolKey memory k,) = initPool(currency0, currency1, IHooks(hookAddr), fee, SQRT_PRICE_1_1);
+
+        IERC20(Currency.unwrap(currency0)).approve(hookAddr, type(uint256).max);
+        IERC20(Currency.unwrap(currency1)).approve(hookAddr, type(uint256).max);
+        h.seedLiquidity(SEED, SEED);
+
+        ys1m.arm(h);
+
+        // zeroForOne swap → hook owes currency1 → withdraw(currency1) in afterSwap → reentrancy attempt.
+        swap(k, true, -1e15, ZERO_BYTES);
+
+        assertTrue(ys1m.reentered(), "reentrancy should have been attempted");
+        assertEq(
+            ys1m.reentryRevertReason(),
+            abi.encodeWithSelector(ReHypothecationHook.Locked.selector),
+            "reentrant liquidity op should be blocked by the swap-cycle lock"
+        );
+    }
+
+    // -- POOL KEY VALIDATION -- //
+
+    function test_validatePoolKey_override_gatesBinding() public {
+        CappedERC4626Mock ys0v = new CappedERC4626Mock(IERC20(Currency.unwrap(currency0)));
+        CappedERC4626Mock ys1v = new CappedERC4626Mock(IERC20(Currency.unwrap(currency1)));
+        address hookAddr = _flagAddr(0x60000000000000000000000000000000);
+        deployCodeTo(
+            "test/general/ReHypothecationHookERC4626.t.sol:ValidatingReHypothecationMock",
+            abi.encode(address(manager), address(ys0v), address(ys1v)),
+            hookAddr
+        );
+
+        // A pool with the wrong fee (1000) is rejected by the override, so the hook stays unbound.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CustomRevert.WrappedError.selector,
+                hookAddr,
+                IHooks.beforeInitialize.selector,
+                abi.encodeWithSelector(ValidatingReHypothecationMock.WrongPool.selector),
+                abi.encodeWithSelector(Hooks.HookCallFailed.selector)
+            )
+        );
+        initPool(currency0, currency1, IHooks(hookAddr), 1000, SQRT_PRICE_1_1);
+
+        // The expected fee (3000) is accepted and binds the hook.
+        initPool(currency0, currency1, IHooks(hookAddr), 3000, SQRT_PRICE_1_1);
+        assertEq(ValidatingReHypothecationMock(payable(hookAddr)).getPoolKey().fee, 3000);
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #155 (base is the `rehypothecation-jit-settlement` branch), which is itself stacked on #151. Merge order: **#151 → #155 → this**. Retarget each base to `master` as the one below it lands.

Two more `ReHypothecationHook` hardening fixes on top of #155.

## Swap-cycle reentrancy lock

The swap path (`beforeSwap`/`afterSwap`) settles deltas through external yield-source calls and isn't eligible for the `nonReentrant` guard (the callbacks aren't fresh entry points). A yield source could therefore reenter `add`/`remove`/`seed` mid-settlement and transact against a transient, inconsistent balance.

This adds a transient swap-cycle lock, set at the start of `beforeSwap` and cleared at the end of `afterSwap` (after the settlement's external calls):
- `seedLiquidity` / `addReHypothecatedLiquidity` / `removeReHypothecatedLiquidity` revert `Locked()` while a cycle is in progress, so they can't reenter during settlement.
- `beforeSwap` reverts if it runs inside a liquidity operation (`_reentrancyGuardEntered()`) or inside another swap cycle, blocking swap-inside-liquidity-op and nested swaps.

The user entrypoints keep their existing `nonReentrant` guard. Together this gives full mutual exclusion between liquidity operations and swap cycles.

## Pool-key validation hook

The first `beforeInitialize` permanently binds the hook to the observed pool, and pool initialization is permissionless, so a third party could front-run and bind the hook to an unintended pool.

This adds an overridable no-op `_validatePoolKey(key)`, called on first initialization, so integrators can pin the hook to an expected pool (currencies, fee, tick spacing), plus a WARNING documenting the risk and the atomic-deploy-then-initialize mitigation. The base stays permissionless and flexible (the library can't know the intended pool); enforcement is opt-in per integrator.

## Tests

Adds a yield source that reenters `removeReHypothecatedLiquidity` during `afterSwap` (asserting it reverts with `Locked()` while the swap still completes), and a hook overriding `_validatePoolKey` (asserting a wrong-fee pool is rejected and the expected one binds). Full suite passes (348 tests).