### PR TITLE
LimitOrderHook: M-15: redeem oversized claims over several settlements

### DIFF
--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -150,7 +150,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     /// @dev The default order id, used to indicate that an order is not yet initialized.
     OrderIdLibrary.OrderId internal constant ORDER_ID_DEFAULT = OrderIdLibrary.OrderId.wrap(0);
 
-    /// @dev The largest amount the `PoolManager` accounts in one settlement, which it takes as an `int128`.
+    /// @dev The largest amount the `PoolManager` settles at once, since it accounts deltas as an `int128`.
     uint256 private constant MAX_SETTLEMENT = uint256(uint128(type(int128).max));
 
     /// @dev The next order id to be used.
@@ -701,8 +701,8 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      * @dev Sends `amount` of `currency` to `to`, redeeming the claims the hook holds for it.
      *
      * An owner's entitlement aggregates batches that each fit in an `int128`, so it can exceed
-     * `MAX_SETTLEMENT` and is redeemed over several settlements. One covers any amount a real token can
-     * produce, and further passes only replace a redemption that would otherwise revert.
+     * `MAX_SETTLEMENT`. It is then redeemed over several settlements, each pass replacing a redemption
+     * that would otherwise revert.
      *
      * Nothing is sent when `amount` is zero, since the transfer it would otherwise make reverts for tokens
      * that reject zero-value transfers, and for recipients that cannot receive the native currency.
@@ -713,9 +713,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         while (amount > 0) {
             uint256 settlement = amount < MAX_SETTLEMENT ? amount : MAX_SETTLEMENT;
 
-            // burn the claims the hook holds for the currency
             poolManager.burn(address(this), id, settlement);
-            // take the currency from the pool and send it to the `to` address
             poolManager.take(currency, to, settlement);
 
             unchecked {

--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -150,6 +150,9 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     /// @dev The default order id, used to indicate that an order is not yet initialized.
     OrderIdLibrary.OrderId internal constant ORDER_ID_DEFAULT = OrderIdLibrary.OrderId.wrap(0);
 
+    /// @dev The largest amount the `PoolManager` accounts in one settlement, which it takes as an `int128`.
+    uint256 private constant MAX_SETTLEMENT = uint256(uint128(type(int128).max));
+
     /// @dev The next order id to be used.
     OrderIdLibrary.OrderId private _orderIdNext = OrderIdLibrary.OrderId.wrap(1);
 
@@ -695,17 +698,30 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     }
 
     /**
-     * @dev Sends `amount` of `currency` to `to`, redeeming the claims the hook holds for it. Returns early when
-     * `amount` is zero, since the transfer it would otherwise make reverts for tokens that reject zero-value
-     * transfers, and for recipients that cannot receive the native currency.
+     * @dev Sends `amount` of `currency` to `to`, redeeming the claims the hook holds for it.
+     *
+     * An owner's entitlement aggregates batches that each fit in an `int128`, so it can exceed
+     * `MAX_SETTLEMENT` and is redeemed over several settlements. One covers any amount a real token can
+     * produce, and further passes only replace a redemption that would otherwise revert.
+     *
+     * Nothing is sent when `amount` is zero, since the transfer it would otherwise make reverts for tokens
+     * that reject zero-value transfers, and for recipients that cannot receive the native currency.
      */
     function _sendFromClaims(Currency currency, address to, uint256 amount) private {
-        if (amount == 0) return;
+        uint256 id = currency.toId();
 
-        // burn the claims the hook holds for the currency
-        poolManager.burn(address(this), currency.toId(), amount);
-        // take the currency from the pool and send it to the `to` address
-        poolManager.take(currency, to, amount);
+        while (amount > 0) {
+            uint256 settlement = amount < MAX_SETTLEMENT ? amount : MAX_SETTLEMENT;
+
+            // burn the claims the hook holds for the currency
+            poolManager.burn(address(this), id, settlement);
+            // take the currency from the pool and send it to the `to` address
+            poolManager.take(currency, to, settlement);
+
+            unchecked {
+                amount -= settlement;
+            }
+        }
     }
 
     /**

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -42,6 +42,15 @@ contract LimitOrderHookTest is HookTest {
     /// @dev Tolerance for the truncation dust of pro-rata splits.
     uint256 constant DUST = 2;
 
+    /**
+     * @dev Donation used to load an order with fees. It stays under `type(int128).max` so that realizing it
+     * does not overflow the pool's own fee accounting.
+     */
+    uint256 constant DONATION = 2 ** 126;
+
+    /// @dev Tolerance for the pool fees the donation cycle accrues alongside the donation itself.
+    uint256 constant SWAP_FEE_DUST = 1e6;
+
     function setUp() public {
         deployFreshManagerAndRouters();
         deployMintAndApprove2Currencies();
@@ -193,6 +202,22 @@ contract LimitOrderHookTest is HookTest {
         swapToLimit(key, true, -1e18, -tickSpacing / 2);
         swapToLimit(noHookKey, true, -1e18, -tickSpacing / 2);
         vm.stopPrank();
+    }
+
+    /**
+     * @dev Swaps into the order's range, donates `amount0` to it, and swaps back out so the tick stays
+     * placeable. The order's liquidity must be the pool's only liquidity for it to earn the whole donation.
+     */
+    function donateToOrder(int24 orderTick, uint256 amount0) internal {
+        vm.prank(swapper);
+        swapToLimit(key, false, -1e6, orderTick + tickSpacing / 2);
+        assertGe(getCurrentTick(key), orderTick, "the donation needs the price inside the order's range");
+
+        donateRouter.donate(key, amount0, 0, ZERO_BYTES);
+
+        vm.prank(swapper);
+        swapToLimit(key, true, -1e6, orderTick - tickSpacing / 2);
+        assertLt(getCurrentTick(key), orderTick, "the order should be out of range again");
     }
 
     function initRejectZeroTransferPool()
@@ -624,6 +649,39 @@ contract LimitOrderHookTest is HookTest {
         assertTrue(thisOwed0 > 0 || thisOwed1 > 0, "prior owner should keep its fees");
     }
 
+    /**
+     * @dev Fees reach the hook in batches that each fit in `int128`, but an owner's entitlement aggregates
+     * them, so it can exceed the amount a single `PoolManager` settlement accepts.
+     */
+    function test_cancelOrder_feesAboveTheSignedSettlementLimit() public {
+        int24 orderTick = tickSpacing;
+
+        // the sole owner of the pool's only liquidity earns every donation
+        hook.placeOrder(key, orderTick, true, 1);
+
+        // each donation is realized on its own over the single unit of liquidity
+        for (uint256 i = 0; i < 2; i++) {
+            donateToOrder(orderTick, DONATION);
+            vm.startPrank(user);
+            hook.placeOrder(key, orderTick, true, 1);
+            hook.cancelOrder(key, orderTick, true, user);
+            vm.stopPrank();
+        }
+
+        (uint256 owed0,) = feesOwedTo(1, address(this));
+        assertGt(owed0, uint256(uint128(type(int128).max)), "the fees owed should exceed one settlement");
+
+        uint256 balanceBefore = currency0.balanceOf(address(this));
+        hook.cancelOrder(key, orderTick, true, address(this));
+
+        assertApproxEqAbs(
+            currency0.balanceOf(address(this)) - balanceBefore,
+            owed0,
+            SWAP_FEE_DUST,
+            "the owner should receive the fees owed"
+        );
+    }
+
     // ------------------------------------- Fill ------------------------------------- //
 
     function test_fill_singleOwner() public {
@@ -987,6 +1045,36 @@ contract LimitOrderHookTest is HookTest {
 
         assertApproxEqAbs(ownerAmount0 - attackerAmount0, preJoin0, DUST, "attacker should not skim currency0 fees");
         assertApproxEqAbs(ownerAmount1 - attackerAmount1, preJoin1, DUST, "attacker should not skim currency1 fees");
+    }
+
+    /// @dev A filled order pays principal and fees together, which is subject to the same settlement limit.
+    function test_withdraw_feesAboveTheSignedSettlementLimit() public {
+        int24 orderTick = tickSpacing;
+
+        hook.placeOrder(key, orderTick, true, 1);
+
+        for (uint256 i = 0; i < 2; i++) {
+            donateToOrder(orderTick, DONATION);
+            vm.startPrank(user);
+            hook.placeOrder(key, orderTick, true, 1);
+            hook.cancelOrder(key, orderTick, true, user);
+            vm.stopPrank();
+        }
+
+        (uint256 owed0,) = feesOwedTo(1, address(this));
+        assertGt(owed0, uint256(uint128(type(int128).max)), "the fees owed should exceed one settlement");
+
+        vm.prank(swapper);
+        swapToLimit(key, false, -1e18, orderTick + 2 * tickSpacing);
+        assertTrue(getOrderInfoView(1).filled, "the order should be filled");
+
+        uint256 balanceBefore = currency0.balanceOf(address(this));
+        (uint256 amount0,) = hook.withdraw(OrderIdLibrary.OrderId.wrap(1), address(this));
+
+        assertGt(amount0, uint256(uint128(type(int128).max)), "the payout should exceed one settlement");
+        assertEq(
+            currency0.balanceOf(address(this)) - balanceBefore, amount0, "the owner should receive the full payout"
+        );
     }
 
     // ------------------------------------- Getters ------------------------------------- //


### PR DESCRIPTION
Fixes M-15: Claim payouts exceed `PoolManager`'s signed settlement limit

`_sendFromClaims` passed an owner's whole entitlement to one `burn` and one `take`, which both cast the
amount to an `int128`. Fees arrive in batches that each fit, but the entitlement aggregates them, so a
large one reverts and leaves both the fees and the principal unclaimable.

Redeems over as many settlements as it takes, each capped at `int128.max`. Adds regression tests on
cancel and withdraw.
