### PR TITLE
LimitOrderHook: L-05 record the baseline for a self-initialized pool

### DIFF
--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -61,7 +61,9 @@ library OrderIdLibrary {
  * IMPORTANT: Uniswap V4 does not call a hook's own callbacks when that hook is the caller, so {_afterSwap}
  * does not run for a swap this hook makes itself. A subclass that swaps internally MUST call
  * {_fillCrossedOrders} afterwards, or the tick recorded for the pool falls behind the price and the next
- * crossing is measured from it.
+ * crossing is measured from it. For the same reason {_afterInitialize} does not run for a pool this hook
+ * initializes itself, so such a subclass MUST call {_recordTickLowerLast} afterwards, or the pool keeps a
+ * tick-zero baseline and the first swap fills every order between tick zero and the price.
  *
  * WARNING: This is experimental software and is provided on an "as is" and "as available" basis. We do
  * not give any warranties and will not be liable for any losses incurred through any use of this code
@@ -230,6 +232,18 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
         _tickLowerLasts[key.toId()] = _getTickLower(tick, key.tickSpacing);
 
         return this.afterInitialize.selector;
+    }
+
+    /**
+     * @dev Records the tick `key` currently sits at as the baseline the next crossing is measured from,
+     * without filling anything.
+     *
+     * IMPORTANT: A subclass that initializes a pool itself must call this, since the pool does not report
+     * such an initialization back to the hook.
+     */
+    function _recordTickLowerLast(PoolKey memory key) internal virtual {
+        PoolId poolId = key.toId();
+        _tickLowerLasts[poolId] = _getTickLower(_getCurrentTick(poolId), key.tickSpacing);
     }
 
     /// @dev Hooks into the `afterSwap` hook to fill the orders the swap crossed.

--- a/src/mocks/general/LimitOrderHookMock.sol
+++ b/src/mocks/general/LimitOrderHookMock.sol
@@ -21,6 +21,16 @@ contract LimitOrderHookMock is LimitOrderHook {
     constructor(IPoolManager _poolManager) BaseHook(_poolManager) {}
 
     /**
+     * @dev Initializes `key` from inside this hook, which the pool does not report back to it. Records the
+     * baseline when `recordTick`, and models the subclass that forgets to otherwise.
+     */
+    function selfInitialize(PoolKey calldata key, uint160 sqrtPriceX96, bool recordTick) external {
+        poolManager.initialize(key, sqrtPriceX96);
+
+        if (recordTick) _recordTickLowerLast(key);
+    }
+
+    /**
      * @dev Swaps `amount` toward `targetTick` from inside this hook's own unlock callback, which the pool
      * does not report. Fills the orders it crossed when `fillCrossed`, and models the subclass that forgets
      * to otherwise.

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -195,6 +195,14 @@ contract LimitOrderHookTest is HookTest {
         vm.stopPrank();
     }
 
+    /// @dev A key this hook can initialize itself, distinct from `key` through its tick spacing.
+    function selfInitKey() internal view returns (PoolKey memory) {
+        return
+            PoolKey({
+                currency0: currency0, currency1: currency1, fee: 3000, tickSpacing: 10, hooks: IHooks(address(hook))
+            });
+    }
+
     function initRejectZeroTransferPool()
         internal
         returns (PoolKey memory poolKey, ERC20RejectZeroTransferMock token, bool tokenIsCurrency0)
@@ -811,6 +819,45 @@ contract LimitOrderHookTest is HookTest {
         assertGt(currentTickLower(), orderTick, "the price should be past the order");
         assertFalse(getOrderInfoView(1).filled, "the crossed order should stay unfilled");
         assertEq(getLiquidityInPosition(key, orderTick, true), liquidity, "liquidity should stay in the pool");
+    }
+
+    function test_fill_selfInitializeDoesNotRecordTheTick() public {
+        PoolKey memory selfKey = selfInitKey();
+
+        hook.selfInitialize(selfKey, TickMath.getSqrtPriceAtTick(6015), false);
+
+        assertEq(getCurrentTick(selfKey), 6015, "the pool should be initialized away from tick zero");
+        assertEq(hook.getTickLowerLast(selfKey.toId()), 0, "the hook should record nothing for it");
+    }
+
+    function test_fill_selfInitializeWithoutRecordFillsUncrossedOrders() public {
+        PoolKey memory selfKey = selfInitKey();
+        hook.selfInitialize(selfKey, TickMath.getSqrtPriceAtTick(6015), false);
+
+        // an order far below the price, which no swap in this test reaches
+        hook.placeOrder(selfKey, 3000, false, 1e12);
+        uint232 orderId = rawOrderIdOf(selfKey, 3000, false);
+
+        vm.prank(swapper);
+        swapToLimit(selfKey, true, -1e6, 6014);
+
+        assertGt(getCurrentTick(selfKey), 3000, "the price should stay above the order");
+        assertTrue(getOrderInfoView(orderId).filled, "the tick-zero baseline fills it anyway");
+    }
+
+    function test_fill_selfInitializeWithRecordLeavesUncrossedOrders() public {
+        PoolKey memory selfKey = selfInitKey();
+        hook.selfInitialize(selfKey, TickMath.getSqrtPriceAtTick(6015), true);
+
+        assertEq(hook.getTickLowerLast(selfKey.toId()), 6010, "the baseline should be the initialization tick");
+
+        hook.placeOrder(selfKey, 3000, false, 1e12);
+        uint232 orderId = rawOrderIdOf(selfKey, 3000, false);
+
+        vm.prank(swapper);
+        swapToLimit(selfKey, true, -1e6, 6014);
+
+        assertFalse(getOrderInfoView(orderId).filled, "an order the price never crossed should stay unfilled");
     }
 
     // ------------------------------------- Withdraw ------------------------------------- //


### PR DESCRIPTION
Fixes L-05: Self-initialization leaves the first swap baseline at tick zero

Uniswap V4 does not call a hook's own callbacks, so `_afterInitialize` does not run for a pool the hook
initializes itself and `_tickLowerLasts` keeps its zero default. The first swap then measures its crossing
from tick zero and fills every order between there and the price.

Adds `_recordTickLowerLast` for a subclass to call after initializing a pool itself, alongside the existing
`_fillCrossedOrders` requirement for its own swaps, and documents both in the same note.
