### PR TITLE
CurrencySettler: document that `payer` must be trusted

### DIFF
--- a/src/utils/CurrencySettler.sol
+++ b/src/utils/CurrencySettler.sol
@@ -26,6 +26,11 @@ library CurrencySettler {
 
     /**
      * @notice Settle (pay) a currency to the `PoolManager`
+     *
+     * IMPORTANT: The funds are pulled from `payer`, while the delta settled belongs to the calling contract.
+     * Derive `payer` from trusted context, given that an untrusted value lets an attacker pay the debt of the
+     * calling contract with an allowance that a third party granted to it.
+     *
      * @param currency Currency to settle
      * @param poolManager `PoolManager` to settle to
      * @param payer Address of the payer, which can be the hook itself or an external address. The native


### PR DESCRIPTION
`settle` pulls the funds from `payer`, while the delta it clears belongs to the calling contract. A caller that derives `payer` from untrusted input therefore lets an attacker pay the debt of the calling contract with an allowance that a third party granted to it.

The hooks in this repository pass either the calling contract or the `msg.sender` captured at unlock time, so this documents the constraint the library already relies on.
