### PR TITLE
LimitOrderHook: fill the direction the price moved, not the swap's

### DIFF
--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -233,13 +233,13 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
     }
 
     /// @dev Hooks into the `afterSwap` hook to fill the orders the swap crossed.
-    function _afterSwap(address, PoolKey calldata key, SwapParams calldata params, BalanceDelta, bytes calldata)
+    function _afterSwap(address, PoolKey calldata key, SwapParams calldata, BalanceDelta, bytes calldata)
         internal
         virtual
         override
         returns (bytes4, int128)
     {
-        _fillCrossedOrders(key, params.zeroForOne);
+        _fillCrossedOrders(key);
 
         return (this.afterSwap.selector, 0);
     }
@@ -578,21 +578,23 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
 
     /**
      * @dev Fills the orders the price crossed since the tick last recorded for `key`, and records the tick
-     * it reached. `swapZeroForOne` is the swap's direction, not the filled orders'.
+     * it reached. Orders fill against the way the price moved over that span. A swap the hook did not
+     * record can leave that opposite to the swap's own direction.
      *
      * IMPORTANT: A subclass that swaps inside its own unlock callback must call this afterwards, since the
      * pool does not report such a swap.
      */
-    function _fillCrossedOrders(PoolKey memory key, bool swapZeroForOne) internal virtual {
+    function _fillCrossedOrders(PoolKey memory key) internal virtual {
         PoolId poolId = key.toId();
         (int24 tickLower, int24 lower, int24 upper) = _getCrossedTicks(poolId, key.tickSpacing);
 
         if (lower > upper) return;
 
+        bool zeroForOne = tickLower >= getTickLowerLast(poolId);
+
         // set the last tick lower for the pool
         _tickLowerLasts[poolId] = tickLower;
 
-        bool zeroForOne = !swapZeroForOne;
         for (; lower <= upper; lower += key.tickSpacing) {
             _fillOrder(key, lower, zeroForOne);
         }

--- a/src/mocks/general/LimitOrderHookMock.sol
+++ b/src/mocks/general/LimitOrderHookMock.sol
@@ -43,7 +43,7 @@ contract LimitOrderHookMock is LimitOrderHook {
 
         BalanceDelta delta = poolManager.swap(key, params, "");
 
-        if (fillCrossed) _fillCrossedOrders(key, params.zeroForOne);
+        if (fillCrossed) _fillCrossedOrders(key);
 
         _settle(key, delta);
 

--- a/test/general/LimitOrderHook.t.sol
+++ b/test/general/LimitOrderHook.t.sol
@@ -813,6 +813,31 @@ contract LimitOrderHookTest is HookTest {
         assertEq(getLiquidityInPosition(key, orderTick, true), liquidity, "liquidity should stay in the pool");
     }
 
+    /// @dev A swap the hook does not record leaves the window spanning orders the price converted moving
+    /// the other way. Filling the swap's direction credits them the currency their owners deposited.
+    function test_fill_unrecordedSwapDoesNotFillAgainstTheWindow() public {
+        fundHook();
+
+        // the hook moves the price down from inside its own unlock callback, which the pool does not
+        // report, so the recorded tick stays above the price
+        hook.internalSwap(key, -10 * tickSpacing, 1e18, false);
+        assertEq(hook.getTickLowerLast(key.toId()), 0, "the hook should record nothing for it");
+
+        int24 orderTick = -5 * tickSpacing;
+        uint128 liquidity = 1e15;
+        hook.placeOrder(key, orderTick, true, liquidity);
+
+        // an upward swap that stops below the order: the window reaches the order, the price does not
+        vm.prank(swapper);
+        swapToLimit(key, false, -1e24, -8 * tickSpacing);
+        assertLt(currentTickLower(), orderTick, "the price should stop below the order");
+
+        OrderInfoView memory order = getOrderInfoView(1);
+        assertFalse(order.filled, "an order the price never reached should not fill");
+        assertEq(order.principalCredited0, 0, "the fill should not credit the deposited currency");
+        assertEq(getLiquidityInPosition(key, orderTick, true), liquidity, "liquidity should stay in the pool");
+    }
+
     // ------------------------------------- Withdraw ------------------------------------- //
 
     function test_withdraw_notFilled_reverts() public {


### PR DESCRIPTION
Follow-up to #153, which let a subclass record its own swaps but left the fill trusting the swap.

The tick window comes from the recorded tick and the live one. The direction to fill came from the
swap. A swap the hook does not record leaves the two disagreeing, so the window spans orders the
price converted moving the other way. Filling those credited the currency their owners deposited and
retired the order id, leaving them unable to cancel or re-place.

Takes the direction from the window instead, which the live tick bounds. Drops the unused parameter.
