### PR TITLE
BaseCustomCurve: report the swap fee in the unspecified currency

### DIFF
--- a/src/base/BaseCustomCurve.sol
+++ b/src/base/BaseCustomCurve.sol
@@ -123,53 +123,29 @@ abstract contract BaseCustomCurve is BaseCustomAccounting {
             returnDelta = toBeforeSwapDelta(-specifiedAmount.toInt128(), unspecifiedAmount.toInt128());
         }
 
-        // Emit the swap event with the amounts ordered correctly and signed per the
-        // `IHookEvents.HookSwap` convention (positive for input, negative for output).
-        // NOTE: the fee is paid in the input currency.
+        // Emit the swap event with the amounts and the fee ordered by currency. The `returnDelta` components
+        // already follow the `IHookEvents.HookSwap` convention, which is positive for input and negative for output.
+        // NOTE: the fee is paid in the unspecified currency.
         if (specified == key.currency0) {
-            if (exactInput) {
-                // currency0 is input, currency1 is output
-                emit HookSwap(
-                    PoolId.unwrap(key.toId()),
-                    sender,
-                    specifiedAmount.toInt128(),
-                    -unspecifiedAmount.toInt128(),
-                    swapFeeAmount.toUint128(),
-                    0
-                );
-            } else {
-                // currency0 is output, currency1 is input
-                emit HookSwap(
-                    PoolId.unwrap(key.toId()),
-                    sender,
-                    -specifiedAmount.toInt128(),
-                    unspecifiedAmount.toInt128(),
-                    0,
-                    swapFeeAmount.toUint128()
-                );
-            }
+            // currency0 is specified, currency1 is unspecified
+            emit HookSwap(
+                PoolId.unwrap(key.toId()),
+                sender,
+                returnDelta.getSpecifiedDelta(),
+                returnDelta.getUnspecifiedDelta(),
+                0,
+                swapFeeAmount.toUint128()
+            );
         } else {
-            if (exactInput) {
-                // currency1 is input, currency0 is output
-                emit HookSwap(
-                    PoolId.unwrap(key.toId()),
-                    sender,
-                    -unspecifiedAmount.toInt128(),
-                    specifiedAmount.toInt128(),
-                    0,
-                    swapFeeAmount.toUint128()
-                );
-            } else {
-                // currency1 is output, currency0 is input
-                emit HookSwap(
-                    PoolId.unwrap(key.toId()),
-                    sender,
-                    unspecifiedAmount.toInt128(),
-                    -specifiedAmount.toInt128(),
-                    swapFeeAmount.toUint128(),
-                    0
-                );
-            }
+            // currency1 is specified, currency0 is unspecified
+            emit HookSwap(
+                PoolId.unwrap(key.toId()),
+                sender,
+                returnDelta.getUnspecifiedDelta(),
+                returnDelta.getSpecifiedDelta(),
+                swapFeeAmount.toUint128(),
+                0
+            );
         }
 
         return (this.beforeSwap.selector, returnDelta, 0);
@@ -287,9 +263,13 @@ abstract contract BaseCustomCurve is BaseCustomAccounting {
     /**
      * @dev Calculate the amount of fees to be paid to LPs in a swap.
      *
+     * The fee is denominated in the unspecified currency, which is the output currency on exact input swaps and the
+     * input currency on exact output swaps. On an exact input swap the hook takes the full specified input from the
+     * pool, so the fee can only be realized as output that the hook retains.
+     *
      * @param params The swap parameters.
      * @param unspecifiedAmount The amount of the unspecified currency to be taken or settled.
-     * @return swapFeeAmount The amount of fees to be paid to LPs in the swap (in currency0 and currency1).
+     * @return swapFeeAmount The amount of fees to be paid to LPs in the swap, denominated in the unspecified currency.
      */
     function _getSwapFeeAmount(SwapParams calldata params, uint256 unspecifiedAmount)
         internal

--- a/src/mocks/base/BaseCustomCurveFeeMock.sol
+++ b/src/mocks/base/BaseCustomCurveFeeMock.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+// External imports
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {SwapParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
+// Internal imports
+import {BaseCustomCurveMock} from "./BaseCustomCurveMock.sol";
+
+/**
+ * @title BaseCustomCurveFeeMock
+ * @dev Constant-sum {BaseCustomCurve} that charges a swap fee for LPs. The fee reduces the output on exact input
+ * swaps and raises the input on exact output swaps, so it accrues in the unspecified currency on both.
+ */
+contract BaseCustomCurveFeeMock is BaseCustomCurveMock {
+    /// @notice The swap fee charged for LPs, defined in basis points (up to 10_000)
+    uint256 private _swapFeeBps;
+
+    constructor(IPoolManager _poolManager) BaseCustomCurveMock(_poolManager) {}
+
+    function setSwapFee(uint256 feeBps) external {
+        _swapFeeBps = feeBps;
+    }
+
+    /// @dev The fee charged on a swap of `amountSpecified`, denominated in the unspecified currency.
+    function swapFee(int256 amountSpecified) public view returns (uint256) {
+        uint256 specifiedAmount = amountSpecified < 0 ? uint256(-amountSpecified) : uint256(amountSpecified);
+        return specifiedAmount * _swapFeeBps / 10_000;
+    }
+
+    function _getUnspecifiedAmount(SwapParams calldata params)
+        internal
+        virtual
+        override
+        returns (uint256 unspecifiedAmount)
+    {
+        unspecifiedAmount = super._getUnspecifiedAmount(params);
+        uint256 fee = swapFee(params.amountSpecified);
+        return params.amountSpecified < 0 ? unspecifiedAmount - fee : unspecifiedAmount + fee;
+    }
+
+    function _getSwapFeeAmount(SwapParams calldata params, uint256)
+        internal
+        virtual
+        override
+        returns (uint256 swapFeeAmount)
+    {
+        return swapFee(params.amountSpecified);
+    }
+}

--- a/test/base/BaseCustomCurve.t.sol
+++ b/test/base/BaseCustomCurve.t.sol
@@ -19,6 +19,7 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 
 // Internal imports
 import {BaseCustomCurveMock} from "../../src/mocks/base/BaseCustomCurveMock.sol";
+import {BaseCustomCurveFeeMock} from "../../src/mocks/base/BaseCustomCurveFeeMock.sol";
 import {HookTest} from "../utils/HookTest.sol";
 
 contract BaseCustomCurveTest is HookTest {
@@ -598,6 +599,87 @@ contract BaseCustomCurveTest is HookTest {
             assertEq(amount0, expected0, string.concat(tag, "amount0 sign/magnitude mismatch"));
             assertEq(amount1, expected1, string.concat(tag, "amount1 sign/magnitude mismatch"));
         }
+    }
+
+    /// @dev Per `IHookEvents.HookSwap` NatSpec: `hookLPfeeAmount0` and `hookLPfeeAmount1` are the LP fees charged in
+    /// currency0 and currency1. The fee accrues in the unspecified currency, which is the output on exact input swaps
+    /// and the input on exact output swaps. Exercises all 4 (zeroForOne x exactInput) combinations in a single test.
+    function test_hookSwap_event_feeOnUnspecifiedCurrency() public {
+        uint160 flags = uint160(
+            Hooks.BEFORE_INITIALIZE_FLAG | Hooks.BEFORE_SWAP_FLAG | Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG
+                | Hooks.BEFORE_ADD_LIQUIDITY_FLAG | Hooks.BEFORE_REMOVE_LIQUIDITY_FLAG
+        );
+        // Deploy above the flag bits, so that the pool differs from the one initialized in `setUp`
+        BaseCustomCurveFeeMock feeHook = BaseCustomCurveFeeMock(payable(address(flags | (uint160(1) << 20))));
+        deployCodeTo(
+            "src/mocks/base/BaseCustomCurveFeeMock.sol:BaseCustomCurveFeeMock",
+            abi.encode(address(manager)),
+            address(feeHook)
+        );
+
+        (key, id) =
+            initPool(currency0, currency1, IHooks(address(feeHook)), LPFeeLibrary.DYNAMIC_FEE_FLAG, SQRT_PRICE_1_1);
+        ERC20(Currency.unwrap(currency0)).approve(address(feeHook), type(uint256).max);
+        ERC20(Currency.unwrap(currency1)).approve(address(feeHook), type(uint256).max);
+
+        feeHook.setSwapFee(300); // 3%
+        feeHook.addLiquidity(
+            BaseCustomAccounting.AddLiquidityParams(
+                10 ether, 10 ether, 9 ether, 9 ether, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0)
+            )
+        );
+
+        for (uint256 i = 0; i < 4; i++) {
+            bool zeroForOne = i < 2;
+            bool exactInput = i % 2 == 0;
+            _assertHookSwapFee(
+                feeHook,
+                zeroForOne,
+                exactInput,
+                string.concat("[zeroForOne=", zeroForOne ? "T" : "F", ", exactInput=", exactInput ? "T" : "F", "] ")
+            );
+        }
+    }
+
+    /// @dev Swaps `0.1 ether` on `feeHook` and asserts that the fee both accrues in and is reported against the
+    /// unspecified currency, which is currency`zeroForOne == exactInput ? 1 : 0`.
+    function _assertHookSwapFee(BaseCustomCurveFeeMock feeHook, bool zeroForOne, bool exactInput, string memory tag)
+        private
+    {
+        int256 amount = 0.1 ether;
+        int256 fee = int256(feeHook.swapFee(amount));
+        assertEq(fee, 0.003 ether, string.concat(tag, "unexpected mock fee"));
+
+        Currency unspecified = zeroForOne == exactInput ? currency1 : currency0;
+        int256 balanceBefore = int256(manager.balanceOf(address(feeHook), unspecified.toId()));
+
+        vm.recordLogs();
+        swapRouter.swap(
+            key,
+            SwapParams({
+                zeroForOne: zeroForOne,
+                amountSpecified: exactInput ? -amount : amount,
+                sqrtPriceLimitX96: zeroForOne ? SQRT_PRICE_1_2 : SQRT_PRICE_2_1
+            }),
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}),
+            ZERO_BYTES
+        );
+
+        // The hook retains the fee in the unspecified currency: on a 1:1 curve it settles `amount - fee` of output
+        // for an exact input swap, and takes `amount + fee` of input for an exact output swap.
+        assertEq(
+            int256(manager.balanceOf(address(feeHook), unspecified.toId())) - balanceBefore,
+            exactInput ? fee - amount : fee + amount,
+            string.concat(tag, "the fee did not accrue in the unspecified currency")
+        );
+
+        (bytes memory data, bool found) = findLogData(vm.getRecordedLogs(), address(feeHook), HookSwap.selector);
+        assertTrue(found, string.concat(tag, "HookSwap not emitted"));
+        (,, uint128 hookLPfeeAmount0, uint128 hookLPfeeAmount1) = abi.decode(data, (int128, int128, uint128, uint128));
+
+        (int256 expectedFee0, int256 expectedFee1) = zeroForOne == exactInput ? (int256(0), fee) : (fee, int256(0));
+        assertEq(int256(uint256(hookLPfeeAmount0)), expectedFee0, string.concat(tag, "hookLPfeeAmount0 mismatch"));
+        assertEq(int256(uint256(hookLPfeeAmount1)), expectedFee1, string.concat(tag, "hookLPfeeAmount1 mismatch"));
     }
 
     /// @dev Per the `BaseCustomCurve._modifyLiquidity` flow, the emitted `HookModifyLiquidity` amounts


### PR DESCRIPTION
`BaseCustomCurve._beforeSwap` derives the swap fee from the unspecified amount but reported it against the input currency. The two agree only on exact output swaps.

On an exact input swap the hook takes the full specified input and settles a reduced output, so the fee is retained output. `HookSwap` now reports it against the unspecified currency, matching `BaseHookFee` and `BaseDynamicAfterFee`. The amount fields keep their values.

`BaseCustomCurveMock` charges no fee, so no test could observe the fee fields. `BaseCustomCurveFeeMock` adds a settable one.