### PR TITLE
BaseCustomCurve and BaseCustomAccounting CEI enforcement

### DIFF
--- a/src/base/BaseCustomAccounting.sol
+++ b/src/base/BaseCustomAccounting.sol
@@ -32,6 +32,10 @@ import {CurrencySettler} from "../utils/CurrencySettler.sol";
  * accounting hook for multiple pools, you must have multiple storage instances of this contract and
  * initialize them via the `PoolManager` with their respective pool keys.
  *
+ * WARNING: The share supply is stale for the length of a liquidity modification, since {_mint} and {_burn} run
+ * once {unlockCallback} returns. Account for it wherever the shares enter a computation, in this hook or in a
+ * contract that reads them.
+ *
  * WARNING: This is experimental software and is provided on an "as is" and "as available" basis. We do
  * not give any warranties and will not be liable for any losses incurred through any use of this code
  * base.
@@ -263,7 +267,7 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
         // Calculate the principal delta
         BalanceDelta principalDelta = callerDelta - feesAccrued;
 
-        // Handle each currency amount based on its sign after applying the liquidity modification
+        // Settle both currencies before sending either one out, so untrusted code sees no one-sided state
         if (principalDelta.amount0() < 0) {
             // If amount0 is negative, send tokens from the sender to the pool. The native currency is paid
             // from this contract, which holds the sender's value for the length of the call
@@ -274,15 +278,19 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
                     uint256(int256(-principalDelta.amount0())),
                     false
                 );
-        } else {
-            // If amount0 is positive, send tokens from the pool to the sender
-            key.currency0.take(poolManager, data.sender, uint256(int256(principalDelta.amount0())), false);
         }
 
         if (principalDelta.amount1() < 0) {
             // If amount1 is negative, send tokens from the sender to the pool
             key.currency1.settle(poolManager, data.sender, uint256(int256(-principalDelta.amount1())), false);
-        } else {
+        }
+
+        if (principalDelta.amount0() > 0) {
+            // If amount0 is positive, send tokens from the pool to the sender
+            key.currency0.take(poolManager, data.sender, uint256(int256(principalDelta.amount0())), false);
+        }
+
+        if (principalDelta.amount1() > 0) {
             // If amount1 is positive, send tokens from the pool to the sender
             key.currency1.take(poolManager, data.sender, uint256(int256(principalDelta.amount1())), false);
         }

--- a/src/base/BaseCustomCurve.sol
+++ b/src/base/BaseCustomCurve.sol
@@ -31,6 +31,10 @@ import {CurrencySettler} from "../utils/CurrencySettler.sol";
  * NOTE: This hook by default does not include fee or salt mechanisms, which can be implemented by inheriting
  * contracts if needed.
  *
+ * WARNING: The share supply is stale for the length of a liquidity modification, since {_mint} and {_burn} run
+ * once {unlockCallback} returns. Account for it wherever the shares enter a computation, in this hook or in a
+ * contract that reads them.
+ *
  * WARNING: This is experimental software and is provided on an "as is" and "as available" basis. We do
  * not give any warranties and will not be liable for any losses incurred through any use of this code
  * base.
@@ -212,39 +216,22 @@ abstract contract BaseCustomCurve is BaseCustomAccounting {
     {
         CallbackDataCustom memory data = abi.decode(rawData, (CallbackDataCustom));
 
-        // slither-disable-next-line uninitialized-local
-        int128 amount0;
-        // slither-disable-next-line uninitialized-local
-        int128 amount1;
-
         // This section handles liquidity modifications (adding/removing) for both tokens in the pool
         // The sign of data.amount0/1 determines if we're removing (-) or adding (+) liquidity
 
         PoolKey memory key = poolKey();
 
-        // Remove liquidity if amount0 is negative
+        // The delta owed to the hook is the opposite of the amounts moved for the user
+        int128 amount0 = -data.amount0;
+        int128 amount1 = -data.amount1;
+
+        // Settle both currencies before taking either one, so untrusted code sees no one-sided state
+
         if (data.amount0 < 0) {
             // Burns ERC-6909 tokens to receive tokens
             key.currency0.settle(poolManager, address(this), uint256(int256(-data.amount0)), true);
-            // Sends tokens from the pool to the user
-            key.currency0.take(poolManager, data.sender, uint256(int256(-data.amount0)), false);
-            // Record the amount so that it can be then encoded into the delta
-            amount0 = -data.amount0;
-        }
-
-        // Remove liquidity if amount1 is negative
-        if (data.amount1 < 0) {
-            // Burns ERC-6909 tokens to receive tokens
-            key.currency1.settle(poolManager, address(this), uint256(int256(-data.amount1)), true);
-            // Sends tokens from the pool to the user
-            key.currency1.take(poolManager, data.sender, uint256(int256(-data.amount1)), false);
-            // Record the amount so that it can be then encoded into the delta
-            amount1 = -data.amount1;
-        }
-
-        // Add liquidity if amount0 is positive
-        if (data.amount0 > 0) {
-            // First settle (send) tokens from user to pool. The native currency is paid from this
+        } else if (data.amount0 > 0) {
+            // Settle (send) tokens from user to pool. The native currency is paid from this
             // contract, which holds the sender's value for the length of the call
             key.currency0
                 .settle(
@@ -253,20 +240,30 @@ abstract contract BaseCustomCurve is BaseCustomAccounting {
                     uint256(int256(data.amount0)),
                     false
                 );
-            // Take (mint) ERC-6909 tokens to be received by this hook
-            key.currency0.take(poolManager, address(this), uint256(int256(data.amount0)), true);
-            // Record the amount so that it can be then encoded into the delta
-            amount0 = -data.amount0;
         }
 
-        // Add liquidity if amount1 is positive
-        if (data.amount1 > 0) {
-            // First settle (send) tokens from user to pool
+        if (data.amount1 < 0) {
+            // Burns ERC-6909 tokens to receive tokens
+            key.currency1.settle(poolManager, address(this), uint256(int256(-data.amount1)), true);
+        } else if (data.amount1 > 0) {
+            // Settle (send) tokens from user to pool
             key.currency1.settle(poolManager, data.sender, uint256(int256(data.amount1)), false);
+        }
+
+        if (data.amount0 < 0) {
+            // Sends tokens from the pool to the user
+            key.currency0.take(poolManager, data.sender, uint256(int256(-data.amount0)), false);
+        } else if (data.amount0 > 0) {
+            // Take (mint) ERC-6909 tokens to be received by this hook
+            key.currency0.take(poolManager, address(this), uint256(int256(data.amount0)), true);
+        }
+
+        if (data.amount1 < 0) {
+            // Sends tokens from the pool to the user
+            key.currency1.take(poolManager, data.sender, uint256(int256(-data.amount1)), false);
+        } else if (data.amount1 > 0) {
             // Take (mint) ERC-6909 tokens to be received by this hook
             key.currency1.take(poolManager, address(this), uint256(int256(data.amount1)), true);
-            // Record the amount so that it can be then encoded into the delta
-            amount1 = -data.amount1;
         }
 
         emit HookModifyLiquidity(PoolId.unwrap(key.toId()), data.sender, amount0, amount1);


### PR DESCRIPTION
`unlockCallback` settled and paid out one currency before it touched the other. Paying out hands execution to untrusted code while the `PoolManager` is unlocked, so a curve pricing from the hook's ERC-6909 claim balances quoted against one post-withdrawal reserve and one pre-withdrawal reserve.

Both currencies are now settled before either one is paid out, in both callbacks. Verified against a constant-product curve pricing from those balances: every attack shape now costs the attacker slippage.

The share supply is still stale for the length of a modification, since `_mint` and `_burn` run once the callback returns. Both contracts warn against computing from it there. Tracked in #164.
