### PR TITLE
Document the reentrancy surface and hook callback behavior

### DIFF
--- a/src/general/LimitOrderHook.sol
+++ b/src/general/LimitOrderHook.sol
@@ -255,6 +255,7 @@ abstract contract LimitOrderHook is BaseHook, IUnlockCallback {
      * Requirements:
      *
      * - `key` must identify a pool configured with this hook, otherwise the order could never be filled.
+     * - `key` must not use the native currency, otherwise it reverts {NativeCurrencyUnsupported}.
      * - The placement must require only the currency being sold, otherwise it reverts {InRange}.
      */
     function placeOrder(PoolKey calldata key, int24 tick, bool zeroForOne, uint128 liquidity)

--- a/src/oracles/panoptic/BaseOracleHook.sol
+++ b/src/oracles/panoptic/BaseOracleHook.sol
@@ -104,6 +104,9 @@ abstract contract BaseOracleHook is BaseHook {
     ///
     /// NOTE: Note that this hook does not return either a `BeforeSwapDelta` or lp fee override — this call is used exclusively for recording price observations.
     ///
+    /// NOTE: The observation records the tick before the swap applies, so it never reflects a price moved within
+    /// the current transaction. A hook that swaps on its own skips this callback and moves the tick unrecorded.
+    ///
     /// @param key The key for the pool
     /// @return bytes4 The function selector for the hook
     /// @return BeforeSwapDelta The hook's delta in specified and unspecified currencies. Positive: the hook is owed/took currency, negative: the hook owes/sent currency

--- a/src/utils/CurrencySettler.sol
+++ b/src/utils/CurrencySettler.sol
@@ -17,6 +17,12 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
  * Based on the https://github.com/Uniswap/v4-core/blob/main/test/utils/CurrencySettler.sol[Uniswap v4 test utils implementation].
  *
  * NOTE: Deltas are synced before any ERC-20 transfers in {settle} function.
+ *
+ * IMPORTANT: Moving an underlying token hands execution to code the hook does not control: {take} calls the
+ * recipient for the native currency, and both {take} and {settle} call the token contract for an ERC-20. The
+ * `PoolManager` is unlocked there, so that code can reach the hook partway through an operation, when the state
+ * it exposes is not yet consistent. Follow checks-effects-interactions and update that state before either call.
+ * The ERC-6909 paths and a native {settle} reach only the `PoolManager`.
  */
 library CurrencySettler {
     using SafeERC20 for IERC20;


### PR DESCRIPTION
`CurrencySettler` records which calls hand execution to code the hook does not control, and the checks-effects-interactions ordering that keeps it safe. Rationale for #166.

`LimitOrderHook` states that a pool key must not use the native currency. `BaseOracleHook` states what its observation records and that a hook swapping on its own skips the callback.
