### PR TITLE
BaseCustomAccounting: M-07 make the position salt derivation overridable

### DIFF
--- a/src/base/BaseCustomAccounting.sol
+++ b/src/base/BaseCustomAccounting.sol
@@ -304,21 +304,12 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
 
     /**
      * @dev Returns the salt of the Uniswap V4 position that a liquidity modification applies to. By default it is
-     * the hash of `sender` and the `salt` returned by {_getAddLiquidity} or {_getRemoveLiquidity}, so a position
-     * belongs to the caller that created it and no other account can modify it.
+     * the hash of `sender` and the salt returned by {_getAddLiquidity} or {_getRemoveLiquidity}, so a position
+     * belongs to the caller that created it.
      *
-     * Override this function to share a position between callers, for example to back fungible liquidity shares
-     * with a single position:
-     *
-     * ```solidity
-     * function _getPositionSalt(address, bytes32 salt) internal view override returns (bytes32) {
-     *     return salt;
-     * }
-     * ```
-     *
-     * IMPORTANT: A salt that does not depend on `sender` lets any caller modify the position. The inheriting
-     * contract must then gate {addLiquidity} and {removeLiquidity} on its own accounting, such as the balance of
-     * a share token.
+     * IMPORTANT: A salt that does not depend on `sender` shares the position between callers. Such an override
+     * must also override {_handleAccruedFees}, which by default pays every fee accrued in the position to
+     * whichever caller modifies it.
      */
     function _getPositionSalt(address sender, bytes32 salt) internal view virtual returns (bytes32) {
         return keccak256(abi.encode(sender, salt));

--- a/src/base/BaseCustomAccounting.sol
+++ b/src/base/BaseCustomAccounting.sol
@@ -32,6 +32,11 @@ import {CurrencySettler} from "../utils/CurrencySettler.sol";
  * accounting hook for multiple pools, you must have multiple storage instances of this contract and
  * initialize them via the `PoolManager` with their respective pool keys.
  *
+ * WARNING: By default every position belongs to the caller that created it, since {_getPositionSalt} derives
+ * the position salt from the caller. Liquidity shares minted as a receipt for such a position must not be
+ * transferable, because the recipient cannot modify the position the shares represent. Override
+ * {_getPositionSalt} to back transferable shares with a position shared between callers.
+ *
  * WARNING: This is experimental software and is provided on an "as is" and "as available" basis. We do
  * not give any warranties and will not be liable for any losses incurred through any use of this code
  * base.
@@ -253,9 +258,8 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
 
         CallbackData memory data = abi.decode(rawData, (CallbackData));
 
-        // Set the salt value of the liquidity position, which is the keccak256 hash of the sender and salt from the callback data
-        // This ensures that each liquidity position is unique and cannot be accessed by other users
-        data.params.salt = keccak256(abi.encode(data.sender, data.params.salt));
+        // Resolve the position the liquidity modification applies to
+        data.params.salt = _getPositionSalt(data.sender, data.params.salt);
 
         // Get liquidity modification deltas
         (BalanceDelta callerDelta, BalanceDelta feesAccrued) = poolManager.modifyLiquidity(key, data.params, "");
@@ -296,6 +300,28 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
 
         // Return both deltas so that slippage checks can be done on the principal delta
         return abi.encode(callerDelta, feesAccrued);
+    }
+
+    /**
+     * @dev Returns the salt of the Uniswap V4 position that a liquidity modification applies to. By default it is
+     * the hash of `sender` and the `salt` returned by {_getAddLiquidity} or {_getRemoveLiquidity}, so a position
+     * belongs to the caller that created it and no other account can modify it.
+     *
+     * Override this function to share a position between callers, for example to back fungible liquidity shares
+     * with a single position:
+     *
+     * ```solidity
+     * function _getPositionSalt(address, bytes32 salt) internal view override returns (bytes32) {
+     *     return salt;
+     * }
+     * ```
+     *
+     * IMPORTANT: A salt that does not depend on `sender` lets any caller modify the position. The inheriting
+     * contract must then gate {addLiquidity} and {removeLiquidity} on its own accounting, such as the balance of
+     * a share token.
+     */
+    function _getPositionSalt(address sender, bytes32 salt) internal view virtual returns (bytes32) {
+        return keccak256(abi.encode(sender, salt));
     }
 
     /**
@@ -367,10 +393,9 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
      * @return shares The liquidity shares to mint.
      *
      * IMPORTANT: The salt returned in `modify` indicates which position of the sender the liquidity
-     * modification is applied given that the `unlockCallback` function uses the keccak256 hash of
-     * the sender and the salt returned here to determine the liquidity position. By default, we
-     * recommend using the `userInputSalt` parameter from the `AddLiquidityParams` struct as the salt
-     * here.
+     * modification is applied to, given that {_getPositionSalt} derives the liquidity position from the
+     * sender and the salt returned here. By default, we recommend using the `userInputSalt` parameter
+     * from the `AddLiquidityParams` struct as the salt here.
      */
     function _getAddLiquidity(uint160 sqrtPriceX96, AddLiquidityParams memory params)
         internal
@@ -387,10 +412,9 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
      * @return shares The liquidity shares to burn.
      *
      * IMPORTANT: The salt returned in `modify` indicates which position of the sender the liquidity
-     * modification is applied given that the `unlockCallback` function uses the keccak256 hash of
-     * the sender and the salt returned here to determine the liquidity position. By default, we
-     * recommend using the `userInputSalt` parameter from the `AddLiquidityParams` struct as the salt
-     * here.
+     * modification is applied to, given that {_getPositionSalt} derives the liquidity position from the
+     * sender and the salt returned here. By default, we recommend using the `userInputSalt` parameter
+     * from the `AddLiquidityParams` struct as the salt here.
      */
     function _getRemoveLiquidity(RemoveLiquidityParams memory params)
         internal

--- a/src/mocks/base/BaseCustomAccountingSharedPositionMock.sol
+++ b/src/mocks/base/BaseCustomAccountingSharedPositionMock.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+// External imports
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+// Internal imports
+import {BaseCustomAccountingMock} from "./BaseCustomAccountingMock.sol";
+
+contract BaseCustomAccountingSharedPositionMock is BaseCustomAccountingMock {
+    constructor(IPoolManager _poolManager) BaseCustomAccountingMock(_poolManager) {}
+
+    function _getPositionSalt(address, bytes32 salt) internal view override returns (bytes32) {
+        return salt;
+    }
+
+    // Exclude from coverage report
+    function test() public override {}
+}

--- a/test/base/BaseCustomAccounting.t.sol
+++ b/test/base/BaseCustomAccounting.t.sol
@@ -19,6 +19,7 @@ import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
 // Internal imports
 import {BaseCustomAccountingFeeMock} from "../../src/mocks/base/BaseCustomAccountingFeeMock.sol";
 import {BaseCustomAccountingMock} from "../../src/mocks/base/BaseCustomAccountingMock.sol";
+import {BaseCustomAccountingSharedPositionMock} from "../../src/mocks/base/BaseCustomAccountingSharedPositionMock.sol";
 import {HookTest} from "../utils/HookTest.sol";
 
 contract BaseCustomAccountingTest is HookTest {
@@ -882,9 +883,12 @@ contract BaseCustomAccountingTest is HookTest {
     }
 
     function test_getPositionSalt_sharedPosition_redeemsTransferredShares() public {
-        SharedPositionMock sharedHook = SharedPositionMock(payable(HOOK_DEPLOYMENT_ADDRESS));
+        BaseCustomAccountingSharedPositionMock sharedHook =
+            BaseCustomAccountingSharedPositionMock(payable(HOOK_DEPLOYMENT_ADDRESS));
         deployCodeTo(
-            "test/base/BaseCustomAccounting.t.sol:SharedPositionMock", abi.encode(address(manager)), address(sharedHook)
+            "src/mocks/base/BaseCustomAccountingSharedPositionMock.sol:BaseCustomAccountingSharedPositionMock",
+            abi.encode(address(manager)),
+            address(sharedHook)
         );
         (key,) =
             initPool(currency0, currency1, IHooks(address(sharedHook)), LPFeeLibrary.DYNAMIC_FEE_FLAG, SQRT_PRICE_1_1);
@@ -910,13 +914,5 @@ contract BaseCustomAccountingTest is HookTest {
         assertEq(sharedHook.balanceOf(recipient), 0);
         assertGt(key.currency0.balanceOf(recipient), 0);
         assertGt(key.currency1.balanceOf(recipient), 0);
-    }
-}
-
-contract SharedPositionMock is BaseCustomAccountingMock {
-    constructor(IPoolManager _poolManager) BaseCustomAccountingMock(_poolManager) {}
-
-    function _getPositionSalt(address, bytes32 salt) internal view override returns (bytes32) {
-        return salt;
     }
 }

--- a/test/base/BaseCustomAccounting.t.sol
+++ b/test/base/BaseCustomAccounting.t.sol
@@ -880,4 +880,43 @@ contract BaseCustomAccountingTest is HookTest {
         assertGt(remAmount0, int128(0), "remove: amount0 should be positive (caller receives)");
         assertGt(remAmount1, int128(0), "remove: amount1 should be positive (caller receives)");
     }
+
+    function test_getPositionSalt_sharedPosition_redeemsTransferredShares() public {
+        SharedPositionMock sharedHook = SharedPositionMock(payable(HOOK_DEPLOYMENT_ADDRESS));
+        deployCodeTo(
+            "test/base/BaseCustomAccounting.t.sol:SharedPositionMock", abi.encode(address(manager)), address(sharedHook)
+        );
+        (key,) =
+            initPool(currency0, currency1, IHooks(address(sharedHook)), LPFeeLibrary.DYNAMIC_FEE_FLAG, SQRT_PRICE_1_1);
+
+        ERC20(Currency.unwrap(currency0)).approve(address(sharedHook), type(uint256).max);
+        ERC20(Currency.unwrap(currency1)).approve(address(sharedHook), type(uint256).max);
+
+        sharedHook.addLiquidity(
+            BaseCustomAccounting.AddLiquidityParams(
+                10 ether, 10 ether, 0, 0, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0)
+            )
+        );
+
+        uint256 shares = sharedHook.balanceOf(address(this));
+        address recipient = makeAddr("recipient");
+        sharedHook.transfer(recipient, shares);
+
+        vm.prank(recipient);
+        sharedHook.removeLiquidity(
+            BaseCustomAccounting.RemoveLiquidityParams(shares, 0, 0, MAX_DEADLINE, MIN_TICK, MAX_TICK, bytes32(0))
+        );
+
+        assertEq(sharedHook.balanceOf(recipient), 0);
+        assertGt(key.currency0.balanceOf(recipient), 0);
+        assertGt(key.currency1.balanceOf(recipient), 0);
+    }
+}
+
+contract SharedPositionMock is BaseCustomAccountingMock {
+    constructor(IPoolManager _poolManager) BaseCustomAccountingMock(_poolManager) {}
+
+    function _getPositionSalt(address, bytes32 salt) internal view override returns (bytes32) {
+        return salt;
+    }
 }


### PR DESCRIPTION
The position salt was hardcoded to `keccak256(sender, salt)`, so a share token minted as a receipt could not be redeemed by a transferee.

`_getPositionSalt` keeps that derivation as the default and lets an implementation share one position between callers. The contract now documents that share receipts must not be transferable unless the override does so.