### PR TITLE
BaseCustomAccounting: M-09 document permissionless pool initialization

### DIFF
--- a/src/base/BaseCustomAccounting.sol
+++ b/src/base/BaseCustomAccounting.sol
@@ -321,6 +321,10 @@ abstract contract BaseCustomAccounting is BaseHook, IHookEvents, IUnlockCallback
     /**
      * @dev Initialize the hook's pool key. The stored key should act immutably so that
      * it can safely be used across the hook's functions.
+     *
+     * WARNING: Pool initialization is permissionless and permanently binds the hook to the first key it sees,
+     * so a third party can front-run it with an unintended pool. Initialize the pool atomically with the hook's
+     * deployment, or override this function to reject an unexpected key.
      */
     function _beforeInitialize(address, PoolKey calldata key, uint160) internal virtual override returns (bytes4) {
         // Check if the pool key is already initialized


### PR DESCRIPTION
The first initializer permanently binds the hook to any structurally valid key, so a third party can front-run the intended pool and force a redeployment. `BaseCustomCurve` inherits this.

`_beforeInitialize` now carries the same warning as `ReHypothecationHook`, which closed the identical finding, and the existing override point lets an inheritor reject an unexpected key.