### PR TITLE
BaseCustomAccountingMock: L-07 size redemptions against position liquidity

### DIFF
--- a/src/mocks/base/BaseCustomAccountingMock.sol
+++ b/src/mocks/base/BaseCustomAccountingMock.sol
@@ -4,12 +4,10 @@ pragma solidity ^0.8.26;
 // External imports
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
-import {FullMath} from "@uniswap/v4-core/src/libraries/FullMath.sol";
 import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
 import {LiquidityAmounts} from "@uniswap/v4-periphery/src/libraries/LiquidityAmounts.sol";
 import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
 import {SafeCast} from "@uniswap/v4-core/src/libraries/SafeCast.sol";
-import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import {ModifyLiquidityParams} from "@uniswap/v4-core/src/types/PoolOperation.sol";
 // Internal imports
 import {BaseCustomAccounting} from "../../base/BaseCustomAccounting.sol";
@@ -17,7 +15,6 @@ import {BaseHook} from "../../base/BaseHook.sol";
 
 contract BaseCustomAccountingMock is BaseCustomAccounting, ERC20 {
     using SafeCast for uint256;
-    using StateLibrary for IPoolManager;
 
     uint256 private _nativeRefund;
 
@@ -58,11 +55,12 @@ contract BaseCustomAccountingMock is BaseCustomAccounting, ERC20 {
 
     function _getRemoveLiquidity(RemoveLiquidityParams memory params)
         internal
-        view
+        pure
         override
         returns (bytes memory, uint256 liquidity)
     {
-        liquidity = FullMath.mulDiv(params.liquidity, poolManager.getLiquidity(poolKey().toId()), totalSupply());
+        // A share is one unit of position liquidity, so redeeming shares removes the same amount of liquidity
+        liquidity = params.liquidity;
 
         return (
             abi.encode(

--- a/test/base/BaseCustomAccounting.t.sol
+++ b/test/base/BaseCustomAccounting.t.sol
@@ -880,4 +880,43 @@ contract BaseCustomAccountingTest is HookTest {
         assertGt(remAmount0, int128(0), "remove: amount0 should be positive (caller receives)");
         assertGt(remAmount1, int128(0), "remove: amount1 should be positive (caller receives)");
     }
+
+    function test_removeLiquidity_inactiveRange_succeeds() public {
+        int24 tickLower = -600;
+        int24 tickUpper = 600;
+
+        hook.addLiquidity(
+            BaseCustomAccounting.AddLiquidityParams(
+                10 ether, 10 ether, 0, 0, MAX_DEADLINE, tickLower, tickUpper, bytes32(0)
+            )
+        );
+
+        uint256 liquidityTokenBal = hook.balanceOf(address(this));
+
+        // Swap the price above the range, so that none of the position's liquidity is active
+        SwapParams memory params =
+            SwapParams({zeroForOne: false, amountSpecified: -100 ether, sqrtPriceLimitX96: SQRT_PRICE_4_1});
+        PoolSwapTest.TestSettings memory settings =
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
+        swapRouter.swap(key, params, settings, ZERO_BYTES);
+
+        assertEq(manager.getLiquidity(id), 0);
+
+        // Above the range the position holds only currency1
+        uint256 prevBalance1 = key.currency1.balanceOf(address(this));
+
+        hook.removeLiquidity(
+            BaseCustomAccounting.RemoveLiquidityParams(
+                liquidityTokenBal, 0, 1, MAX_DEADLINE, tickLower, tickUpper, bytes32(0)
+            )
+        );
+
+        // The position is fully redeemed even though no liquidity was active
+        assertEq(hook.balanceOf(address(this)), 0);
+        (uint128 positionLiquidity,,) = manager.getPositionInfo(
+            id, address(hook), tickLower, tickUpper, keccak256(abi.encode(address(this), bytes32(0)))
+        );
+        assertEq(positionLiquidity, 0);
+        assertGt(key.currency1.balanceOf(address(this)), prevBalance1);
+    }
 }


### PR DESCRIPTION
`_getRemoveLiquidity` priced redemptions from `getLiquidity(poolId)`, which counts only liquidity active at the current tick, while shares are minted per unit of position liquidity across every range. One inactive range undersized every redemption, and a fully inactive range made removal a no-op that burned no shares.

A share is one unit of position liquidity, so the conversion is the identity. The old expression agreed with it only when every position was active, which is every existing test.